### PR TITLE
Change runnable tasks logging behavior and add more checks to avoid null usage + Register tasks with Game Instance

### DIFF
--- a/Source/AzSpeech/Private/AzSpeech/Runnables/Bases/AzSpeechRunnableBase.cpp
+++ b/Source/AzSpeech/Private/AzSpeech/Runnables/Bases/AzSpeechRunnableBase.cpp
@@ -36,6 +36,8 @@ bool FAzSpeechRunnableBase::IsPendingStop() const
 
 bool FAzSpeechRunnableBase::Init()
 {
+	StoreThreadInformation();
+
 	UE_LOG(LogAzSpeech_Internal, Display, TEXT("Thread: %s; Function: %s; Message: Initializing runnable thread"), *GetThreadName(), *FString(__func__));
 	
 	return CanInitializeTask();
@@ -390,5 +392,11 @@ const int32 FAzSpeechRunnableBase::GetTimeout() const
 
 const FString FAzSpeechRunnableBase::GetThreadName() const
 {
-	return FThreadManager::Get().GetThreadName(FPlatformTLS::GetCurrentThreadId());
+	return ThreadName.ToString();
+}
+
+void FAzSpeechRunnableBase::StoreThreadInformation()
+{
+	const FString& ThreadNameRef = FThreadManager::Get().GetThreadName(FPlatformTLS::GetCurrentThreadId());
+	ThreadName = *ThreadNameRef;
 }

--- a/Source/AzSpeech/Private/AzSpeech/Runnables/Bases/AzSpeechRunnableBase.cpp
+++ b/Source/AzSpeech/Private/AzSpeech/Runnables/Bases/AzSpeechRunnableBase.cpp
@@ -55,6 +55,8 @@ void FAzSpeechRunnableBase::Stop()
 
 void FAzSpeechRunnableBase::Exit()
 {
+	FScopeLock Lock_Runnable(&Mutex);
+
 	ClearSignals();
 
 	if (!IsValid(GetOwningTask()))
@@ -62,7 +64,7 @@ void FAzSpeechRunnableBase::Exit()
 		return;
 	}
 
-	FScopeLock Lock(&GetOwningTask()->Mutex);
+	FScopeLock Lock_Task(&GetOwningTask()->Mutex);
 
 	UE_LOG(LogAzSpeech_Internal, Display, TEXT("Thread: %s; Function: %s; Message: Exiting thread"), *GetThreadName(), *FString(__func__));
 

--- a/Source/AzSpeech/Private/AzSpeech/Tasks/Bases/AzSpeechSynthesizerTaskBase.cpp
+++ b/Source/AzSpeech/Private/AzSpeech/Tasks/Bases/AzSpeechSynthesizerTaskBase.cpp
@@ -165,7 +165,12 @@ void UAzSpeechSynthesizerTaskBase::LogSynthesisResultStatus(const bool bSuccess)
 }
 
 void UAzSpeechSynthesizerTaskBase::ValidateVoiceName()
-{	
+{
+	if (bIsSSMLBased)
+	{
+		return;
+	}
+
 	const auto Settings = UAzSpeechSettings::GetAzSpeechKeys();
 	if (HasEmptyParameters(VoiceName) || VoiceName.Equals("Default", ESearchCase::IgnoreCase))
 	{

--- a/Source/AzSpeech/Private/AzSpeech/Tasks/Bases/AzSpeechTaskBase.cpp
+++ b/Source/AzSpeech/Private/AzSpeech/Tasks/Bases/AzSpeechTaskBase.cpp
@@ -151,7 +151,12 @@ void UAzSpeechTaskBase::PrePIEEnded(bool bIsSimulating)
 #endif
 
 void UAzSpeechTaskBase::ValidateLanguageID()
-{	
+{
+	if (bIsSSMLBased)
+	{
+		return;
+	}
+
 	const auto Settings = UAzSpeechSettings::GetAzSpeechKeys();
 	if (HasEmptyParameters(LanguageID) || LanguageID.Equals("Default", ESearchCase::IgnoreCase))
 	{

--- a/Source/AzSpeech/Private/AzSpeech/Tasks/Bases/AzSpeechWavFileSynthesisBase.cpp
+++ b/Source/AzSpeech/Private/AzSpeech/Tasks/Bases/AzSpeechWavFileSynthesisBase.cpp
@@ -73,7 +73,8 @@ bool UAzSpeechWavFileSynthesisBase::StartAzureTaskWork()
 		return false;
 	}
 
-	if (HasEmptyParameters(SynthesisText, VoiceName, LanguageID, FilePath, FileName))
+	if (HasEmptyParameters(SynthesisText, FilePath, FileName) ||
+		(!bIsSSMLBased && HasEmptyParameters(VoiceName, LanguageID)))
 	{
 		return false;
 	}

--- a/Source/AzSpeech/Private/AzSpeech/Tasks/RecognitionMapCheckAsync.cpp
+++ b/Source/AzSpeech/Private/AzSpeech/Tasks/RecognitionMapCheckAsync.cpp
@@ -16,6 +16,7 @@ URecognitionMapCheckAsync* URecognitionMapCheckAsync::RecognitionMapCheckAsync(c
 	NewAsyncTask->GroupName = GroupName;
 	NewAsyncTask->bStopAtFirstTrigger = bStopAtFirstTrigger;
 	NewAsyncTask->TaskName = *FString(__func__);
+	NewAsyncTask->RegisterWithGameInstance(WorldContextObject);
 
 	return NewAsyncTask;
 }

--- a/Source/AzSpeech/Private/AzSpeech/Tasks/SSMLToAudioDataAsync.cpp
+++ b/Source/AzSpeech/Private/AzSpeech/Tasks/SSMLToAudioDataAsync.cpp
@@ -11,6 +11,7 @@ USSMLToAudioDataAsync* USSMLToAudioDataAsync::SSMLToAudioData(const UObject* Wor
 	NewAsyncTask->SynthesisText = SynthesisSSML;
 	NewAsyncTask->bIsSSMLBased = true;
 	NewAsyncTask->TaskName = *FString(__func__);
+	NewAsyncTask->RegisterWithGameInstance(WorldContextObject);
 
 	return NewAsyncTask;
 }

--- a/Source/AzSpeech/Private/AzSpeech/Tasks/SSMLToSoundWaveAsync.cpp
+++ b/Source/AzSpeech/Private/AzSpeech/Tasks/SSMLToSoundWaveAsync.cpp
@@ -13,6 +13,7 @@ USSMLToSoundWaveAsync* USSMLToSoundWaveAsync::SSMLToSoundWave(const UObject* Wor
 	NewAsyncTask->SynthesisText = SynthesisSSML;
 	NewAsyncTask->bIsSSMLBased = true;
 	NewAsyncTask->TaskName = *FString(__func__);
+	NewAsyncTask->RegisterWithGameInstance(WorldContextObject);
 
 	return NewAsyncTask;
 }

--- a/Source/AzSpeech/Private/AzSpeech/Tasks/SSMLToSpeechAsync.cpp
+++ b/Source/AzSpeech/Private/AzSpeech/Tasks/SSMLToSpeechAsync.cpp
@@ -11,6 +11,7 @@ USSMLToSpeechAsync* USSMLToSpeechAsync::SSMLToSpeech(const UObject* WorldContext
 	NewAsyncTask->SynthesisText = SynthesisSSML;
 	NewAsyncTask->bIsSSMLBased = true;
 	NewAsyncTask->TaskName = *FString(__func__);
+	NewAsyncTask->RegisterWithGameInstance(WorldContextObject);
 
 	return NewAsyncTask;
 }

--- a/Source/AzSpeech/Private/AzSpeech/Tasks/SSMLToWavFileAsync.cpp
+++ b/Source/AzSpeech/Private/AzSpeech/Tasks/SSMLToWavFileAsync.cpp
@@ -13,6 +13,7 @@ USSMLToWavFileAsync* USSMLToWavFileAsync::SSMLToWavFile(const UObject* WorldCont
 	NewAsyncTask->FileName = FileName;
 	NewAsyncTask->bIsSSMLBased = true;
 	NewAsyncTask->TaskName = *FString(__func__);
+	NewAsyncTask->RegisterWithGameInstance(WorldContextObject);
 
 	return NewAsyncTask;
 }

--- a/Source/AzSpeech/Private/AzSpeech/Tasks/SpeechToTextAsync.cpp
+++ b/Source/AzSpeech/Private/AzSpeech/Tasks/SpeechToTextAsync.cpp
@@ -12,7 +12,9 @@ USpeechToTextAsync* USpeechToTextAsync::SpeechToText(const UObject* WorldContext
 	NewAsyncTask->LanguageID = LanguageID;
 	NewAsyncTask->AudioInputDeviceID = AudioInputDeviceID;
 	NewAsyncTask->PhraseListGroup = PhraseListGroup;
+	NewAsyncTask->bIsSSMLBased = false;
 	NewAsyncTask->TaskName = *FString(__func__);
+	NewAsyncTask->RegisterWithGameInstance(WorldContextObject);
 
 	return NewAsyncTask;
 }

--- a/Source/AzSpeech/Private/AzSpeech/Tasks/TextToAudioDataAsync.cpp
+++ b/Source/AzSpeech/Private/AzSpeech/Tasks/TextToAudioDataAsync.cpp
@@ -8,11 +8,12 @@ UTextToAudioDataAsync* UTextToAudioDataAsync::TextToAudioData(const UObject* Wor
 {
 	UTextToAudioDataAsync* const NewAsyncTask = NewObject<UTextToAudioDataAsync>();
 	NewAsyncTask->WorldContextObject = WorldContextObject;
-	NewAsyncTask->SynthesisText = SynthesisText ;
+	NewAsyncTask->SynthesisText = SynthesisText;
 	NewAsyncTask->VoiceName = VoiceName;
 	NewAsyncTask->LanguageID = LanguageID;
 	NewAsyncTask->bIsSSMLBased = false;
 	NewAsyncTask->TaskName = *FString(__func__);
+	NewAsyncTask->RegisterWithGameInstance(WorldContextObject);
 
 	return NewAsyncTask;
 }

--- a/Source/AzSpeech/Private/AzSpeech/Tasks/TextToSoundWaveAsync.cpp
+++ b/Source/AzSpeech/Private/AzSpeech/Tasks/TextToSoundWaveAsync.cpp
@@ -10,11 +10,12 @@ UTextToSoundWaveAsync* UTextToSoundWaveAsync::TextToSoundWave(const UObject* Wor
 {
 	UTextToSoundWaveAsync* const NewAsyncTask = NewObject<UTextToSoundWaveAsync>();
 	NewAsyncTask->WorldContextObject = WorldContextObject;
-	NewAsyncTask->SynthesisText = SynthesisText ;
+	NewAsyncTask->SynthesisText = SynthesisText;
 	NewAsyncTask->VoiceName = VoiceName;
 	NewAsyncTask->LanguageID = LanguageID;
 	NewAsyncTask->bIsSSMLBased = false;
 	NewAsyncTask->TaskName = *FString(__func__);
+	NewAsyncTask->RegisterWithGameInstance(WorldContextObject);
 
 	return NewAsyncTask;
 }

--- a/Source/AzSpeech/Private/AzSpeech/Tasks/TextToSpeechAsync.cpp
+++ b/Source/AzSpeech/Private/AzSpeech/Tasks/TextToSpeechAsync.cpp
@@ -8,11 +8,12 @@ UTextToSpeechAsync* UTextToSpeechAsync::TextToSpeech(const UObject* WorldContext
 {
 	UTextToSpeechAsync* const NewAsyncTask = NewObject<UTextToSpeechAsync>();
 	NewAsyncTask->WorldContextObject = WorldContextObject;
-	NewAsyncTask->SynthesisText = SynthesisText ;
+	NewAsyncTask->SynthesisText = SynthesisText;
 	NewAsyncTask->VoiceName = VoiceName;
 	NewAsyncTask->LanguageID = LanguageID;
 	NewAsyncTask->bIsSSMLBased = false;
 	NewAsyncTask->TaskName = *FString(__func__);
+	NewAsyncTask->RegisterWithGameInstance(WorldContextObject);
 
 	return NewAsyncTask;
 }

--- a/Source/AzSpeech/Private/AzSpeech/Tasks/TextToWavFileAsync.cpp
+++ b/Source/AzSpeech/Private/AzSpeech/Tasks/TextToWavFileAsync.cpp
@@ -8,13 +8,14 @@ UTextToWavFileAsync* UTextToWavFileAsync::TextToWavFile(const UObject* WorldCont
 {
 	UTextToWavFileAsync* const NewAsyncTask = NewObject<UTextToWavFileAsync>();
 	NewAsyncTask->WorldContextObject = WorldContextObject;
-	NewAsyncTask->SynthesisText = SynthesisText ;
+	NewAsyncTask->SynthesisText = SynthesisText;
 	NewAsyncTask->FilePath = FilePath;
 	NewAsyncTask->FileName = FileName;
 	NewAsyncTask->VoiceName = VoiceName;
 	NewAsyncTask->LanguageID = LanguageID;
 	NewAsyncTask->bIsSSMLBased = false;
 	NewAsyncTask->TaskName = *FString(__func__);
+	NewAsyncTask->RegisterWithGameInstance(WorldContextObject);
 
 	return NewAsyncTask;
 }

--- a/Source/AzSpeech/Private/AzSpeech/Tasks/WavFileToTextAsync.cpp
+++ b/Source/AzSpeech/Private/AzSpeech/Tasks/WavFileToTextAsync.cpp
@@ -14,7 +14,9 @@ UWavFileToTextAsync* UWavFileToTextAsync::WavFileToText(const UObject* WorldCont
 	NewAsyncTask->FileName = FileName;
 	NewAsyncTask->LanguageID = LanguageID;
 	NewAsyncTask->PhraseListGroup = PhraseListGroup;
+	NewAsyncTask->bIsSSMLBased = false;
 	NewAsyncTask->TaskName = *FString(__func__);
+	NewAsyncTask->RegisterWithGameInstance(WorldContextObject);
 
 	return NewAsyncTask;
 }

--- a/Source/AzSpeech/Public/AzSpeech/Runnables/AzSpeechRecognitionRunnable.h
+++ b/Source/AzSpeech/Public/AzSpeech/Runnables/AzSpeechRecognitionRunnable.h
@@ -35,6 +35,10 @@ private:
 	std::shared_ptr<Microsoft::CognitiveServices::Speech::SpeechRecognizer> SpeechRecognizer;
 
 protected:
+	const bool IsSpeechRecognizerValid() const;
+
+	class UAzSpeechRecognizerTaskBase* GetOwningRecognizerTask() const;
+
 	virtual void ClearSignals() override;
 	virtual void RemoveBindings() override;
 

--- a/Source/AzSpeech/Public/AzSpeech/Runnables/AzSpeechSynthesisRunnable.h
+++ b/Source/AzSpeech/Public/AzSpeech/Runnables/AzSpeechSynthesisRunnable.h
@@ -30,6 +30,10 @@ private:
 	std::shared_ptr<Microsoft::CognitiveServices::Speech::SpeechSynthesizer> SpeechSynthesizer;
 
 protected:
+	const bool IsSpeechSynthesizerValid() const;
+
+	class UAzSpeechSynthesizerTaskBase* GetOwningSynthesizerTask() const;
+
 	virtual void ClearSignals() override;
 	virtual void RemoveBindings() override;
 

--- a/Source/AzSpeech/Public/AzSpeech/Runnables/Bases/AzSpeechRunnableBase.h
+++ b/Source/AzSpeech/Public/AzSpeech/Runnables/Bases/AzSpeechRunnableBase.h
@@ -134,4 +134,5 @@ private:
 	TUniquePtr<FRunnableThread> Thread;
 	UAzSpeechTaskBase* OwningTask;
 	std::shared_ptr<Microsoft::CognitiveServices::Speech::Audio::AudioConfig> AudioConfig;
+	mutable FCriticalSection Mutex;
 };

--- a/Source/AzSpeech/Public/AzSpeech/Runnables/Bases/AzSpeechRunnableBase.h
+++ b/Source/AzSpeech/Public/AzSpeech/Runnables/Bases/AzSpeechRunnableBase.h
@@ -50,8 +50,8 @@ protected:
 	
 	typedef FAzSpeechRunnableBase Super;
 
-	UAzSpeechTaskBase* OwningTask;
-	std::shared_ptr<Microsoft::CognitiveServices::Speech::Audio::AudioConfig> AudioConfig;
+	UAzSpeechTaskBase* GetOwningTask() const;
+	std::shared_ptr<Microsoft::CognitiveServices::Speech::Audio::AudioConfig> GetAudioConfig() const;
 	
 	virtual bool InitializeAzureObject();
 	virtual bool CanInitializeTask();
@@ -95,6 +95,8 @@ protected:
 
 	static const int64 GetTimeInMilliseconds();
 	const int32 GetTimeout() const;
+
+	const FString GetThreadName() const;
 	
 #if !UE_BUILD_SHIPPING
 	template<typename TaskTy>
@@ -130,4 +132,6 @@ protected:
 private:
 	bool bStopTask = false;
 	TUniquePtr<FRunnableThread> Thread;
+	UAzSpeechTaskBase* OwningTask;
+	std::shared_ptr<Microsoft::CognitiveServices::Speech::Audio::AudioConfig> AudioConfig;
 };

--- a/Source/AzSpeech/Public/AzSpeech/Runnables/Bases/AzSpeechRunnableBase.h
+++ b/Source/AzSpeech/Public/AzSpeech/Runnables/Bases/AzSpeechRunnableBase.h
@@ -130,6 +130,10 @@ protected:
 #endif
 
 private:
+	FName ThreadName;
+
+	void StoreThreadInformation();
+
 	bool bStopTask = false;
 	TUniquePtr<FRunnableThread> Thread;
 	UAzSpeechTaskBase* OwningTask;

--- a/Source/AzSpeech/Public/AzSpeech/Tasks/Bases/AzSpeechSynthesizerTaskBase.h
+++ b/Source/AzSpeech/Public/AzSpeech/Tasks/Bases/AzSpeechSynthesizerTaskBase.h
@@ -95,7 +95,6 @@ public:
 protected:
 	FString VoiceName;
 	FString SynthesisText;
-	bool bIsSSMLBased;
 	
 	void StartSynthesisWork(const std::shared_ptr<Microsoft::CognitiveServices::Speech::Audio::AudioConfig>& InAudioConfig);
 	

--- a/Source/AzSpeech/Public/AzSpeech/Tasks/Bases/AzSpeechTaskBase.h
+++ b/Source/AzSpeech/Public/AzSpeech/Tasks/Bases/AzSpeechTaskBase.h
@@ -25,31 +25,31 @@ class AZSPEECH_API UAzSpeechTaskBase : public UBlueprintAsyncActionBase
 {
 	GENERATED_BODY()
 
-		friend class FAzSpeechRunnableBase;
+	friend class FAzSpeechRunnableBase;
 
 public:
 	virtual void Activate() override;
 
 	UFUNCTION(BlueprintCallable, Category = "AzSpeech", meta = (DisplayName = "Stop AzSpeech Task"))
-		virtual void StopAzSpeechTask();
+	virtual void StopAzSpeechTask();
 
 	UFUNCTION(BlueprintPure, Category = "AzSpeech")
-		bool IsTaskActive() const;
+	bool IsTaskActive() const;
 
 	UFUNCTION(BlueprintPure, Category = "AzSpeech")
 		bool IsTaskReadyToDestroy() const;
 
 	UFUNCTION(BlueprintPure, Category = "AzSpeech")
-		static const bool IsTaskStillValid(const UAzSpeechTaskBase* Test);
+	static const bool IsTaskStillValid(const UAzSpeechTaskBase* Test);
 
 	UFUNCTION(BlueprintPure, Category = "AzSpeech")
-		const bool IsUsingAutoLanguage() const;
+	const bool IsUsingAutoLanguage() const;
 
 	UFUNCTION(BlueprintPure, Category = "AzSpeech")
-		const FString GetTaskName() const;
+	const FString GetTaskName() const;
 
 	UFUNCTION(BlueprintPure, Category = "AzSpeech")
-		const FString GetLanguageID() const;
+	const FString GetLanguageID() const;
 
 	virtual void SetReadyToDestroy() override;
 

--- a/Source/AzSpeech/Public/AzSpeech/Tasks/Bases/AzSpeechTaskBase.h
+++ b/Source/AzSpeech/Public/AzSpeech/Tasks/Bases/AzSpeechTaskBase.h
@@ -25,44 +25,45 @@ class AZSPEECH_API UAzSpeechTaskBase : public UBlueprintAsyncActionBase
 {
 	GENERATED_BODY()
 
-	friend class FAzSpeechRunnableBase;
+		friend class FAzSpeechRunnableBase;
 
 public:
 	virtual void Activate() override;
 
 	UFUNCTION(BlueprintCallable, Category = "AzSpeech", meta = (DisplayName = "Stop AzSpeech Task"))
-	virtual void StopAzSpeechTask();
+		virtual void StopAzSpeechTask();
 
 	UFUNCTION(BlueprintPure, Category = "AzSpeech")
-	bool IsTaskActive() const;
+		bool IsTaskActive() const;
 
 	UFUNCTION(BlueprintPure, Category = "AzSpeech")
-	bool IsTaskReadyToDestroy() const;
+		bool IsTaskReadyToDestroy() const;
 
 	UFUNCTION(BlueprintPure, Category = "AzSpeech")
-	static const bool IsTaskStillValid(const UAzSpeechTaskBase* Test);
+		static const bool IsTaskStillValid(const UAzSpeechTaskBase* Test);
 
 	UFUNCTION(BlueprintPure, Category = "AzSpeech")
-	const bool IsUsingAutoLanguage() const;
+		const bool IsUsingAutoLanguage() const;
 
 	UFUNCTION(BlueprintPure, Category = "AzSpeech")
-	const FString GetTaskName() const;
+		const FString GetTaskName() const;
 
 	UFUNCTION(BlueprintPure, Category = "AzSpeech")
-	const FString GetLanguageID() const;
+		const FString GetLanguageID() const;
 
 	virtual void SetReadyToDestroy() override;
 
 protected:
 	TSharedPtr<class FAzSpeechRunnableBase> RunnableTask;
 	FName TaskName = NAME_None;
-	
+
 	FString LanguageID;
 	const UObject* WorldContextObject;
+	bool bIsSSMLBased = false;
 
 	virtual bool StartAzureTaskWork();
 	virtual void BroadcastFinalResult();
-	
+
 	mutable FCriticalSection Mutex;
 
 #if WITH_EDITOR
@@ -86,6 +87,6 @@ protected:
 private:
 	bool bIsTaskActive = false;
 	bool bIsReadyToDestroy = false;
-	
+
 	void ValidateLanguageID();
 };

--- a/Source/AzSpeech/Public/AzSpeech/Tasks/Bases/AzSpeechTaskBase.h
+++ b/Source/AzSpeech/Public/AzSpeech/Tasks/Bases/AzSpeechTaskBase.h
@@ -37,7 +37,7 @@ public:
 	bool IsTaskActive() const;
 
 	UFUNCTION(BlueprintPure, Category = "AzSpeech")
-		bool IsTaskReadyToDestroy() const;
+	bool IsTaskReadyToDestroy() const;
 
 	UFUNCTION(BlueprintPure, Category = "AzSpeech")
 	static const bool IsTaskStillValid(const UAzSpeechTaskBase* Test);


### PR DESCRIPTION
Fixes #68 

## Problem
1. The project was crashing randomly and throwing the EXCEPTION_ACCESS_VIOLATION exception sometimes when a runnable thread was trying to finish. This issue appears to be caused because the thread was trying to access the already invalidated AzSpeech task to use his mutex and also remove the delegate. Causing 2 errors:
1.1. The runnable task was trying to lock the mutex owned by the task but the task already doesn't exists.
1.2. When the task identify that the owning task is invalid, the log to inform this was trying to use the invalid task to get his name and ID.

## Solution
1. Check if the task is still valid before trying to perform the thread ending (if already invalidated, abort)
2. Change the logging to use the thread name instead the task name & id and add more verifications via getters