### PR TITLE
Remove 'lib' from the libraries names in Android UPL

### DIFF
--- a/Source/ThirdParty/AzureWrapper/AzSpeech_UPL_Android.xml
+++ b/Source/ThirdParty/AzureWrapper/AzSpeech_UPL_Android.xml
@@ -22,16 +22,16 @@
     </resourceCopies>
     
     <soLoadLibrary>        
-        <loadLibrary name="libMicrosoft.CognitiveServices.Speech.core"                     
+        <loadLibrary name="Microsoft.CognitiveServices.Speech.core"                     
                      failmsg="libMicrosoft.CognitiveServices.Speech.core library not loaded and may be required for AzSpeech." />
         
-        <loadLibrary name="libMicrosoft.CognitiveServices.Speech.extension.audio.sys"
+        <loadLibrary name="Microsoft.CognitiveServices.Speech.extension.audio.sys"
                      failmsg="libMicrosoft.CognitiveServices.Speech.extension.audio.sys library not loaded and may be required for AzSpeech." />
         
-        <loadLibrary name="libMicrosoft.CognitiveServices.Speech.extension.kws"
+        <loadLibrary name="Microsoft.CognitiveServices.Speech.extension.kws"
                      failmsg="libMicrosoft.CognitiveServices.Speech.core library not loaded and may be required for AzSpeech." />
         
-        <loadLibrary name="libMicrosoft.CognitiveServices.Speech.extension.lu"
+        <loadLibrary name="Microsoft.CognitiveServices.Speech.extension.lu"
                      failmsg="libMicrosoft.CognitiveServices.Speech.extension.lu library not loaded and may be required for AzSpeech." />
     </soLoadLibrary>
 </root>

--- a/Source/ThirdParty/AzureWrapper/AzSpeech_UPL_Android.xml
+++ b/Source/ThirdParty/AzureWrapper/AzSpeech_UPL_Android.xml
@@ -23,15 +23,15 @@
     
     <soLoadLibrary>        
         <loadLibrary name="Microsoft.CognitiveServices.Speech.core"                     
-                     failmsg="libMicrosoft.CognitiveServices.Speech.core library not loaded and may be required for AzSpeech." />
+                     failmsg="Microsoft.CognitiveServices.Speech.core library not loaded and may be required for AzSpeech." />
         
         <loadLibrary name="Microsoft.CognitiveServices.Speech.extension.audio.sys"
-                     failmsg="libMicrosoft.CognitiveServices.Speech.extension.audio.sys library not loaded and may be required for AzSpeech." />
+                     failmsg="Microsoft.CognitiveServices.Speech.extension.audio.sys library not loaded and may be required for AzSpeech." />
         
         <loadLibrary name="Microsoft.CognitiveServices.Speech.extension.kws"
-                     failmsg="libMicrosoft.CognitiveServices.Speech.core library not loaded and may be required for AzSpeech." />
+                     failmsg="Microsoft.CognitiveServices.Speech.core library not loaded and may be required for AzSpeech." />
         
         <loadLibrary name="Microsoft.CognitiveServices.Speech.extension.lu"
-                     failmsg="libMicrosoft.CognitiveServices.Speech.extension.lu library not loaded and may be required for AzSpeech." />
+                     failmsg="Microsoft.CognitiveServices.Speech.extension.lu library not loaded and may be required for AzSpeech." />
     </soLoadLibrary>
 </root>


### PR DESCRIPTION
Fixes #58 

This was causing errors when the plugin was trying to load the AzureSDK Libs