### PR TITLE
Change the loading & linkage of the runtime dependencies

### DIFF
--- a/AzSpeech.uplugin
+++ b/AzSpeech.uplugin
@@ -1,7 +1,7 @@
 {
 	"FileVersion": 3,
 	"Version": 7,
-	"VersionName": "1.3.9",
+	"VersionName": "1.3.10",
 	"FriendlyName": "AzSpeech - Voice and Text",
 	"Description": "Integrates Azure Speech Cognitive Services to the Engine by adding functions to perform recognition and synthesis via asynchronous tasks.",
 	"Category": "Game Features",

--- a/AzSpeech.uplugin
+++ b/AzSpeech.uplugin
@@ -1,6 +1,6 @@
 {
 	"FileVersion": 3,
-	"Version": 7,
+	"Version": 8,
 	"VersionName": "1.3.10",
 	"FriendlyName": "AzSpeech - Voice and Text",
 	"Description": "Integrates Azure Speech Cognitive Services to the Engine by adding functions to perform recognition and synthesis via asynchronous tasks.",

--- a/Source/AzSpeech/Private/AzSpeech.cpp
+++ b/Source/AzSpeech/Private/AzSpeech.cpp
@@ -42,13 +42,14 @@ FString GetRuntimeLibsDirectory()
 	const FString PluginBaseDir = PluginInterface->GetBaseDir();
 	const FString LastPluginBinary = GetWhitelistedRuntimeLibs().Top();
 
-	UE_LOG(LogAzSpeech_Internal, Display, TEXT("%s: Performing a search for the AzSpeech runtime dependencies. Root Directory: \"%s\"; Bait File: \"%s\"."), *FString(__func__), *PluginBaseDir, *LastPluginBinary);
+	UE_LOG(LogAzSpeech_Internal, Display, TEXT("%s: Performing a search for the AzSpeech runtime libraries. Root Directory: \"%s\"; Bait File: \"%s\"."), *FString(__func__), *PluginBaseDir, *LastPluginBinary);
 
 	TArray<FString> FoundFiles;
 	IFileManager::Get().FindFilesRecursive(FoundFiles, *PluginBaseDir, *LastPluginBinary, true, false, false);
 
 	if (AzSpeech::Internal::HasEmptyParam(FoundFiles))
 	{
+		UE_LOG(LogAzSpeech_Internal, Error, TEXT("%s: Failed to get the location of the runtime libraries. Please check and validate your installation."), *FString(__func__));
 		return FString();
 	}
 

--- a/Source/AzSpeech/Private/AzSpeech.cpp
+++ b/Source/AzSpeech/Private/AzSpeech.cpp
@@ -40,7 +40,9 @@ FString GetRuntimeLibsDirectory()
 {
 	const TSharedPtr<IPlugin> PluginInterface = IPluginManager::Get().FindPlugin("AzSpeech");
 	const FString PluginBaseDir = PluginInterface->GetBaseDir();
-	const FString& LastPluginBinary = GetWhitelistedRuntimeLibs().Top();
+	const FString LastPluginBinary = GetWhitelistedRuntimeLibs().Top();
+
+	UE_LOG(LogAzSpeech_Internal, Display, TEXT("%s: Performing a search for the AzSpeech runtime dependencies. Root Directory: \"%s\"; Bait File: \"%s\"."), *FString(__func__), *PluginBaseDir, *LastPluginBinary);
 
 	TArray<FString> FoundFiles;
 	IFileManager::Get().FindFilesRecursive(FoundFiles, *PluginBaseDir, *LastPluginBinary, true, false, false);

--- a/Source/AzSpeech/Public/AzSpeech.h
+++ b/Source/AzSpeech/Public/AzSpeech.h
@@ -23,7 +23,7 @@ public:
 	virtual void StartupModule() override;
 	virtual void ShutdownModule() override;
 
-#ifdef AZSPEECH_BINARIES_SUBDIRECTORY
+#ifdef AZSPEECH_RUNTIME_PLATFORM
 private:
 	void LoadRuntimeLibraries();
 	void UnloadRuntimeLibraries();

--- a/Source/ThirdParty/AzureWrapper/AzureWrapper.Build.cs
+++ b/Source/ThirdParty/AzureWrapper/AzureWrapper.Build.cs
@@ -149,15 +149,14 @@ public class AzureWrapper : ModuleRules
 		PublicAdditionalLibraries.Add(Path.Combine(Directory, Filename));
 	}
 
-	private void DefineDependenciesSubDirectory()
+	private void DefineRuntimePlatform()
 	{
-		if (Target.Platform == UnrealTargetPlatform.Win64 || Target.Platform == UnrealTargetPlatform.HoloLens)
+		if (Target.Platform == UnrealTargetPlatform.Win64 ||
+			Target.Platform == UnrealTargetPlatform.HoloLens ||
+			Target.Platform == UnrealTargetPlatform.Mac ||
+			Target.Platform.ToString().ToLower().Contains("linux"))
 		{
-			PublicDefinitions.Add(string.Format("AZSPEECH_BINARIES_SUBDIRECTORY=\"{0}\"", GetBinariesSubDirectory().Replace(@"\", @"\\")));
-		}
-		else if (Target.Platform == UnrealTargetPlatform.Mac || Target.Platform.ToString().ToLower().Contains("linux"))
-		{
-			PublicDefinitions.Add(string.Format("AZSPEECH_BINARIES_SUBDIRECTORY=\"{0}\"", GetBinariesSubDirectory().Replace(@"\", @"/")));
+			PublicDefinitions.Add("AZSPEECH_RUNTIME_PLATFORM=1");
 		}
 	}
 
@@ -184,7 +183,7 @@ public class AzureWrapper : ModuleRules
 		Console.WriteLine("AzSpeech: Initializing build for target: Platform: " + Target.Platform.ToString() + "; Architecture: " + Target.Architecture.ToString() + ";");
 		Console.WriteLine("AzSpeech: Getting plugin dependencies in directory: \"" + GetPlatformLibsDirectory() + "\"");
 
-		DefineDependenciesSubDirectory();
+		DefineRuntimePlatform();
 		DefineWhitelistedDependencies();
 
 		if (Target.Platform == UnrealTargetPlatform.Win64 || Target.Platform == UnrealTargetPlatform.HoloLens)


### PR DESCRIPTION
Close #90 

## Changes
* Change the definition that was used to save the binaries location and tell that the current platform will use the runtime libs
* Set the binaries directory getter to perform a search using the last dependency of the whitelisted binaries as "bait file" to get the path inside the plugin's root directory.