### PR TITLE
v1.3.11 hotfix: Remove lib search and add definitions to get the location of the runtimes in editor and packaged projects

### DIFF
--- a/AzSpeech.uplugin
+++ b/AzSpeech.uplugin
@@ -1,7 +1,7 @@
 {
 	"FileVersion": 3,
 	"Version": 8,
-	"VersionName": "1.3.10",
+	"VersionName": "1.3.11",
 	"FriendlyName": "AzSpeech - Voice and Text",
 	"Description": "Integrates Azure Speech Cognitive Services to the Engine by adding functions to perform recognition and synthesis via asynchronous tasks.",
 	"Category": "Game Features",


### PR DESCRIPTION
Fix #97