### PR TITLE
hotfix: set param as default to self to avoid multiple inputs in blueprint pure node

### DIFF
--- a/Source/AzSpeech/Public/AzSpeech/Tasks/Bases/AzSpeechTaskBase.h
+++ b/Source/AzSpeech/Public/AzSpeech/Tasks/Bases/AzSpeechTaskBase.h
@@ -39,7 +39,7 @@ public:
 	UFUNCTION(BlueprintPure, Category = "AzSpeech")
 	bool IsTaskReadyToDestroy() const;
 
-	UFUNCTION(BlueprintPure, Category = "AzSpeech")
+	UFUNCTION(BlueprintPure, Category = "AzSpeech", meta = (DefaultToSelf = "Test"))
 	static const bool IsTaskStillValid(const UAzSpeechTaskBase* Test);
 
 	UFUNCTION(BlueprintPure, Category = "AzSpeech")


### PR DESCRIPTION
do not increment ver.