### PR TITLE
Get Modules Helper + Viseme Data Filter + Failed Delegates

### DIFF
--- a/AzSpeech.uplugin
+++ b/AzSpeech.uplugin
@@ -1,7 +1,7 @@
 {
 	"FileVersion": 3,
-	"Version": 13,
-	"VersionName": "1.4.5",
+	"Version": 14,
+	"VersionName": "1.4.6",
 	"FriendlyName": "AzSpeech - Voice and Text",
 	"Description": "Integrates Azure Speech Cognitive Services into the Engine by adding functions to perform recognition and synthesis via asynchronous tasks.",
 	"Category": "Game Features",

--- a/Source/AzSpeech/AzSpeech.Build.cs
+++ b/Source/AzSpeech/AzSpeech.Build.cs
@@ -30,7 +30,8 @@ public class AzSpeech : ModuleRules
 			"AndroidPermission",
 			"DeveloperSettings",
 			"AudioCaptureCore",
-			"AssetRegistry"
+			"AssetRegistry",
+			"Projects"
 		});
 
 		if (Target.bBuildEditor)

--- a/Source/AzSpeech/Private/AzSpeech/AzSpeechSettings.cpp
+++ b/Source/AzSpeech/Private/AzSpeech/AzSpeechSettings.cpp
@@ -13,7 +13,7 @@
 #include UE_INLINE_GENERATED_CPP_BY_NAME(AzSpeechSettings)
 #endif
 
-UAzSpeechSettings::UAzSpeechSettings(const FObjectInitializer& ObjectInitializer) : Super(ObjectInitializer), APIAccessKey(FString()), RegionID(FString()), LanguageID(FString()), VoiceName(FString()), ProfanityFilter(EAzSpeechProfanityFilter::Raw), SegmentationSilenceTimeoutMs(1000), InitialSilenceTimeoutMs(5000), bEnableViseme(true), SpeechSynthesisOutputFormat(EAzSpeechSynthesisOutputFormat::Riff16Khz16BitMonoPcm), SpeechRecognitionOutputFormat(EAzSpeechRecognitionOutputFormat::Detailed), TimeOutInSeconds(10.f), TasksThreadPriority(EAzSpeechThreadPriority::Normal), ThreadUpdateInterval(0.033334f), bEnableSDKLogs(true), bEnableInternalLogs(false), bEnableDebuggingLogs(false), StringDelimiters(" ,.;:[]{}!'\"?")
+UAzSpeechSettings::UAzSpeechSettings(const FObjectInitializer& ObjectInitializer) : Super(ObjectInitializer), APIAccessKey(FString()), RegionID(FString()), LanguageID(FString()), VoiceName(FString()), ProfanityFilter(EAzSpeechProfanityFilter::Raw), SegmentationSilenceTimeoutMs(1000), InitialSilenceTimeoutMs(5000), bEnableViseme(true), bFilterVisemeFacialExpression(true), SpeechSynthesisOutputFormat(EAzSpeechSynthesisOutputFormat::Riff16Khz16BitMonoPcm), SpeechRecognitionOutputFormat(EAzSpeechRecognitionOutputFormat::Detailed), TimeOutInSeconds(10.f), TasksThreadPriority(EAzSpeechThreadPriority::Normal), ThreadUpdateInterval(0.033334f), bEnableSDKLogs(true), bEnableInternalLogs(false), bEnableDebuggingLogs(false), StringDelimiters(" ,.;:[]{}!'\"?")
 {
 	CategoryName = TEXT("Plugins");
 

--- a/Source/AzSpeech/Private/AzSpeech/Runnables/AzSpeechSynthesisRunnable.cpp
+++ b/Source/AzSpeech/Private/AzSpeech/Runnables/AzSpeechSynthesisRunnable.cpp
@@ -243,11 +243,18 @@ bool FAzSpeechSynthesisRunnable::ConnectVisemeSignal()
 		return false;
 	}
 
+	bFilterVisemeData = SynthesizerTask->bIsSSMLBased && UAzSpeechSettings::Get()->bFilterVisemeFacialExpression && SynthesizerTask->SynthesisText.Contains("<mstts:viseme type=\"FacialExpression\"/>", ESearchCase::IgnoreCase);
+
 	SpeechSynthesizer->VisemeReceived.Connect([this, SynthesizerTask](const Microsoft::CognitiveServices::Speech::SpeechSynthesisVisemeEventArgs& VisemeEventArgs)
 	{
 		if (!UAzSpeechTaskStatus::IsTaskStillValid(SynthesizerTask))
 		{
 			StopAzSpeechRunnableTask();
+			return;
+		}
+
+		if (bFilterVisemeData && VisemeEventArgs.Animation.empty())
+		{
 			return;
 		}
 

--- a/Source/AzSpeech/Private/AzSpeech/Runnables/Bases/AzSpeechRunnableBase.cpp
+++ b/Source/AzSpeech/Private/AzSpeech/Runnables/Bases/AzSpeechRunnableBase.cpp
@@ -72,13 +72,14 @@ void FAzSpeechRunnableBase::Exit()
 	FScopeLock Lock_Runnable(&Mutex);
 	UE_LOG(LogAzSpeech_Internal, Display, TEXT("Thread: %s; Function: %s; Message: Exiting thread"), *GetThreadName(), *FString(__func__));
 
+	ClearSignals();
+
 	if (UAzSpeechTaskStatus::IsTaskActive(GetOwningTask()))
 	{
 		FScopeLock Lock_Task(&GetOwningTask()->Mutex);
 		AsyncTask(ENamedThreads::GameThread, [this] { GetOwningTask()->BroadcastFinalResult(); });
 	}
 
-	ClearSignals();
 	RemoveBindings();
 
 	if (UAzSpeechTaskStatus::IsTaskStillValid(GetOwningTask()) && !UAzSpeechTaskStatus::IsTaskReadyToDestroy(GetOwningTask()))

--- a/Source/AzSpeech/Public/AzSpeech/AzSpeechHelper.h
+++ b/Source/AzSpeech/Public/AzSpeech/AzSpeechHelper.h
@@ -44,11 +44,31 @@ public:
 		return QualifyFileExtension(Path, Name, "xml");
 	}
 
-	/* Convert .wav file to USoundWave - [OutputModuleName, RelativeOutputDirectory, OutputAssetName]: Used to save the generated audio data in project's content */
+	/* 
+		Convert .wav file to USoundWave.
+
+		[OutputModuleName, RelativeOutputDirectory, OutputAssetName]: Used to save the generated audio data in project's content. Set empty values to generate a transient Sound Wave
+
+		OutputModuleName: Name of the module that will be used to save the generated audio data in project's content. Example: Game. 
+		RelativeOutputDirectory: Directory where the sound wave will be saved
+		OutputAssetName: Name of the generated Sound Wave
+
+		Use GetAvailableContentModules or look at the Audio Generator tool to check available modules
+	*/
 	UFUNCTION(BlueprintCallable, Category = "AzSpeech", Meta = (DisplayName = "Convert .wav file to USoundWave"))
 	static USoundWave* ConvertWavFileToSoundWave(const FString& FilePath, const FString& FileName, const FString& OutputModulePath = "", const FString& RelativeOutputDirectory = "", const FString& OutputAssetName = "");
 
-	/* Convert audio data (TArray<uint8>) to USoundWave - [OutputModuleName, RelativeOutputDirectory, OutputAssetName]: Used to save the generated audio data in project's content */
+	/* 
+		Convert audio data (TArray<uint8>) to USoundWave.
+
+		[OutputModuleName, RelativeOutputDirectory, OutputAssetName]: Used to save the generated audio data in project's content. Set empty values to generate a transient Sound Wave
+
+		OutputModuleName: Name of the module that will be used to save the generated audio data in project's content. Example: Game. 
+		RelativeOutputDirectory: Directory where the sound wave will be saved
+		OutputAssetName: Name of the generated Sound Wave
+
+		Use GetAvailableContentModules or look at the Audio Generator tool to check available modules
+	*/
 	UFUNCTION(BlueprintCallable, Category = "AzSpeech")
 	static USoundWave* ConvertAudioDataToSoundWave(const TArray<uint8>& RawData, const FString& OutputModulePath = "", const FString& RelativeOutputDirectory = "", const FString& OutputAssetName = "");
 
@@ -83,6 +103,9 @@ public:
 
 	UFUNCTION(BlueprintPure, Category = "AzSpeech", Meta = (DisplayName = "Is Audio Input Device ID Valid"))
 	static const bool IsAudioInputDeviceIDValid(const FString& DeviceID);
+
+	UFUNCTION(BlueprintPure, Category = "AzSpeech")
+	static const TArray<FString> GetAvailableContentModules();
 
 	static const FString GetAzSpeechLogsBaseDir();
 };

--- a/Source/AzSpeech/Public/AzSpeech/AzSpeechSettings.h
+++ b/Source/AzSpeech/Public/AzSpeech/AzSpeechSettings.h
@@ -95,6 +95,10 @@ public:
 	UPROPERTY(GlobalConfig, EditAnywhere, Category = "Tasks", Meta = (DisplayName = "Enable Viseme"))
 	bool bEnableViseme;
 
+	/* If enabled, SSML synthesizers tasks with viseme output type set to FacialExpression will return only data that contains the Animation property */
+	UPROPERTY(GlobalConfig, EditAnywhere, Category = "Tasks", Meta = (DisplayName = "Filter Viseme Facial Expression"))
+	bool bFilterVisemeFacialExpression;
+
 	/* Synthesis audio output format */
 	UPROPERTY(GlobalConfig, EditAnywhere, Category = "Tasks", Meta = (DisplayName = "Synthesis Output Format"))
 	EAzSpeechSynthesisOutputFormat SpeechSynthesisOutputFormat;

--- a/Source/AzSpeech/Public/AzSpeech/Runnables/AzSpeechSynthesisRunnable.h
+++ b/Source/AzSpeech/Public/AzSpeech/Runnables/AzSpeechSynthesisRunnable.h
@@ -48,4 +48,6 @@ private:
 	bool ProcessSynthesisResult(const std::shared_ptr<Microsoft::CognitiveServices::Speech::SpeechSynthesisResult>& LastResult);
 
 	const Microsoft::CognitiveServices::Speech::SpeechSynthesisOutputFormat GetOutputFormat() const;
+
+	bool bFilterVisemeData = false;
 };

--- a/Source/AzSpeech/Public/AzSpeech/Tasks/Bases/AzSpeechRecognizerTaskBase.h
+++ b/Source/AzSpeech/Public/AzSpeech/Tasks/Bases/AzSpeechRecognizerTaskBase.h
@@ -40,6 +40,10 @@ public:
 	UPROPERTY(BlueprintAssignable, Category = "AzSpeech")
 	FAzSpeechTaskGenericDelegate RecognitionStarted;
 
+	/* Task delegate that will be called when failed */
+	UPROPERTY(BlueprintAssignable, Category = "AzSpeech")
+	FAzSpeechTaskGenericDelegate RecognitionFailed;
+
 	UFUNCTION(BlueprintPure, Category = "AzSpeech")
 	const FString GetRecognizedString() const;
 	

--- a/Source/AzSpeech/Public/AzSpeech/Tasks/Bases/AzSpeechSynthesizerTaskBase.h
+++ b/Source/AzSpeech/Public/AzSpeech/Tasks/Bases/AzSpeechSynthesizerTaskBase.h
@@ -67,6 +67,10 @@ public:
 	UPROPERTY(BlueprintAssignable, Category = "AzSpeech")
 	FAzSpeechTaskGenericDelegate SynthesisStarted;
 
+	/* Task delegate that will be called when failed */
+	UPROPERTY(BlueprintAssignable, Category = "AzSpeech")
+	FAzSpeechTaskGenericDelegate SynthesisFailed;
+
 	/* Task delegate that will be called when receive a new viseme data */
 	UPROPERTY(BlueprintAssignable, Category = "AzSpeech")
 	FVisemeReceived VisemeReceived;

--- a/Source/AzSpeechEditor/AzSpeechEditor.Build.cs
+++ b/Source/AzSpeechEditor/AzSpeechEditor.Build.cs
@@ -27,8 +27,7 @@ public class AzSpeechEditor : ModuleRules
             "ToolMenus",
             "Slate",
             "SlateCore",
-            "WorkspaceMenuStructure",
-            "Projects"
+            "WorkspaceMenuStructure"
         });
     }
 }

--- a/Source/AzSpeechEditor/Private/SAzSpeechAudioGenerator.cpp
+++ b/Source/AzSpeechEditor/Private/SAzSpeechAudioGenerator.cpp
@@ -15,7 +15,6 @@
 #include <Widgets/Layout/SScrollBox.h>
 #include <Kismet/GameplayStatics.h>
 #include <Sound/SoundWave.h>
-#include <Interfaces/IPluginManager.h>
 
 #ifdef UE_INLINE_GENERATED_CPP_BY_NAME
 #include UE_INLINE_GENERATED_CPP_BY_NAME(SAzSpeechAudioGenerator)
@@ -305,21 +304,8 @@ TArray<TSharedPtr<FString>> SAzSpeechAudioGenerator::GetStringArrayAsSharedPtr(c
 
 TArray<TSharedPtr<FString>> SAzSpeechAudioGenerator::GetAvailableContentModules() const
 {
-	TArray<FString> Output;
-
-	IPluginManager& PluginManager = IPluginManager::Get();
-	const TArray<TSharedRef<IPlugin>> PluginsArray = PluginManager.GetEnabledPluginsWithContent();
-
-	for (const TSharedRef<IPlugin>& Plugin : PluginsArray)
-	{
-		if (Plugin->GetLoadedFrom() != EPluginLoadedFrom::Project)
-		{
-			continue;
-		}
-
-		Output.Add(Plugin->GetName());
-	}
-
+	TArray<FString> Output = UAzSpeechHelper::GetAvailableContentModules();
+	Output.Remove("Game");
 	return GetStringArrayAsSharedPtr(Output);
 }
 


### PR DESCRIPTION
## Changes
* Add a new function to get the available content modules
* Add a check to avoid crashes if the user passes an invalid module in sound wave generatiors
* Improve the comments in sound wave generator functions
* Add new delegates to synthesis & recognition tasks: '... Failed'
* Add a new setting to filter SSML Viseme Data if the type is set to FacialExpression
* Update version

![image](https://user-images.githubusercontent.com/77353979/223442527-413c55b7-8ca4-4643-a8a6-1028a06575e2.png)

Close #142 
Close #145 
Close #143 