### PR TITLE
Fixes on tasks broadcasts & Sound Wave Generation + New Functions

### DIFF
--- a/AzSpeech.uplugin
+++ b/AzSpeech.uplugin
@@ -1,7 +1,7 @@
 {
 	"FileVersion": 3,
-	"Version": 14,
-	"VersionName": "1.4.6",
+	"Version": 15,
+	"VersionName": "1.4.7",
 	"FriendlyName": "AzSpeech - Voice and Text",
 	"Description": "Integrates Azure Speech Cognitive Services into the Engine by adding functions to perform recognition and synthesis via asynchronous tasks.",
 	"Category": "Game Features",

--- a/Config/DefaultAzSpeech.ini
+++ b/Config/DefaultAzSpeech.ini
@@ -123,3 +123,6 @@
 +FunctionRedirects=(OldName="AzSpeechTaskBase.IsTaskActive", NewName="AzSpeechTaskStatus.IsTaskActive")
 +FunctionRedirects=(OldName="AzSpeechTaskBase.IsTaskReadyToDestroy", NewName="AzSpeechTaskStatus.IsTaskReadyToDestroy")
 +FunctionRedirects=(OldName="AzSpeechTaskBase.IsTaskStillValid", NewName="AzSpeechTaskStatus.IsTaskStillValid")
+
+; v1.4.7
++FunctionRedirects=(OldName="AzSpeechSynthesizerTaskBase.GetVisemeData", NewName="AzSpeechSynthesizerTaskBase.GetLastVisemeData")

--- a/Source/AzSpeech/AzSpeech.Build.cs
+++ b/Source/AzSpeech/AzSpeech.Build.cs
@@ -31,7 +31,8 @@ public class AzSpeech : ModuleRules
 			"DeveloperSettings",
 			"AudioCaptureCore",
 			"AssetRegistry",
-			"Projects"
+			"Projects",
+			"Json"
 		});
 
 		if (Target.bBuildEditor)

--- a/Source/AzSpeech/Private/AzSpeech/AzSpeechAnimationData.cpp
+++ b/Source/AzSpeech/Private/AzSpeech/AzSpeechAnimationData.cpp
@@ -1,0 +1,9 @@
+// Author: Lucas Vilas-Boas
+// Year: 2023
+// Repo: https://github.com/lucoiso/UEAzSpeech
+
+#include "AzSpeech/AzSpeechAnimationData.h"
+
+#ifdef UE_INLINE_GENERATED_CPP_BY_NAME
+#include UE_INLINE_GENERATED_CPP_BY_NAME(AzSpeechAnimationData)
+#endif

--- a/Source/AzSpeech/Private/AzSpeech/AzSpeechHelper.cpp
+++ b/Source/AzSpeech/Private/AzSpeech/AzSpeechHelper.cpp
@@ -512,7 +512,7 @@ const FAzSpeechAnimationData UAzSpeechHelper::ExtractAnimationDataFromVisemeData
 		FAzSpeechBlendShapes CurrentBlendShapes;
 		for (const TSharedPtr<FJsonValue>& IteratorValue : IteratorArray->AsArray())
 		{
-			CurrentBlendShapes.Data.Add(IteratorValue->AsNumber());
+			CurrentBlendShapes.Data.Add(static_cast<float>(IteratorValue->AsNumber()));
 		}
 		
 		Output.BlendShapes.Add(CurrentBlendShapes);

--- a/Source/AzSpeech/Private/AzSpeech/AzSpeechHelper.cpp
+++ b/Source/AzSpeech/Private/AzSpeech/AzSpeechHelper.cpp
@@ -149,8 +149,8 @@ USoundWave* UAzSpeechHelper::ConvertAudioDataToSoundWave(const TArray<uint8>& Ra
 	FWaveModInfo WaveInfo;
 	WaveInfo.ReadWaveInfo(RawData.GetData(), RawData.Num());
 
-	const int32 ChannelCount = *WaveInfo.pChannels;
-	const int32 SizeOfSample = *WaveInfo.pBitsPerSample / 8;
+	const int32 ChannelCount = static_cast<int32>(*WaveInfo.pChannels);
+	const int32 SizeOfSample = (*WaveInfo.pBitsPerSample) / 8;
 	const int32 NumSamples = WaveInfo.SampleDataSize / SizeOfSample;
 	const int32 NumFrames = NumSamples / ChannelCount;
 
@@ -209,7 +209,7 @@ USoundWave* UAzSpeechHelper::ConvertAudioDataToSoundWave(const TArray<uint8>& Ra
 		SoundWave->RawPCMData = static_cast<uint8*>(FMemory::Malloc(WaveInfo.SampleDataSize));
 		FMemory::Memcpy(SoundWave->RawPCMData, WaveInfo.SampleDataStart, WaveInfo.SampleDataSize);
 
-		SoundWave->Duration = NumFrames / *WaveInfo.pSamplesPerSec;
+		SoundWave->Duration = static_cast<float>(NumFrames) / *WaveInfo.pSamplesPerSec;
 		SoundWave->SetSampleRate(*WaveInfo.pSamplesPerSec);
 		SoundWave->NumChannels = ChannelCount;
 		SoundWave->TotalSamples = *WaveInfo.pSamplesPerSec * SoundWave->Duration;
@@ -225,6 +225,7 @@ USoundWave* UAzSpeechHelper::ConvertAudioDataToSoundWave(const TArray<uint8>& Ra
 			NewCuePoint.FrameLength = static_cast<int32>(WaveCue.SampleLength);
 			NewCuePoint.FramePosition = static_cast<int32>(WaveCue.Position);
 			NewCuePoint.Label = WaveCue.Label;
+
 			SoundWave->CuePoints.Add(NewCuePoint);
 		}
 #endif
@@ -248,8 +249,6 @@ USoundWave* UAzSpeechHelper::ConvertAudioDataToSoundWave(const TArray<uint8>& Ra
 #elif ENGINE_MAJOR_VERSION == 5
 		SoundWave->SetSoundAssetCompressionType(ESoundAssetCompressionType::BinkAudio);
 #endif
-
-		FAudioThread::RunCommandOnAudioThread([SoundWave]() { SoundWave->InvalidateCompressedData(true, false); });
 #endif
 
 		if (bCreatedNewPackage)

--- a/Source/AzSpeech/Private/AzSpeech/AzSpeechVisemeData.cpp
+++ b/Source/AzSpeech/Private/AzSpeech/AzSpeechVisemeData.cpp
@@ -1,0 +1,9 @@
+// Author: Lucas Vilas-Boas
+// Year: 2023
+// Repo: https://github.com/lucoiso/UEAzSpeech
+
+#include "AzSpeech/AzSpeechVisemeData.h"
+
+#ifdef UE_INLINE_GENERATED_CPP_BY_NAME
+#include UE_INLINE_GENERATED_CPP_BY_NAME(AzSpeechVisemeData)
+#endif

--- a/Source/AzSpeech/Private/AzSpeech/Runnables/AzSpeechRecognitionRunnable.cpp
+++ b/Source/AzSpeech/Private/AzSpeech/Runnables/AzSpeechRecognitionRunnable.cpp
@@ -65,7 +65,7 @@ uint32 FAzSpeechRecognitionRunnable::Run()
 #endif
 
 	const float SleepTime = GetThreadUpdateInterval();
-	
+
 	while (!IsPendingStop())
 	{
 		FPlatformProcess::Sleep(SleepTime);
@@ -80,7 +80,9 @@ uint32 FAzSpeechRecognitionRunnable::Run()
 
 void FAzSpeechRecognitionRunnable::Exit()
 {
-	Super::Exit();
+	FScopeLock Lock(&Mutex);
+
+	Super::Stop();
 
 	if (SpeechRecognizer)
 	{
@@ -108,35 +110,6 @@ UAzSpeechRecognizerTaskBase* FAzSpeechRecognitionRunnable::GetOwningRecognizerTa
 	}
 
 	return Cast<UAzSpeechRecognizerTaskBase>(GetOwningTask());
-}
-
-void FAzSpeechRecognitionRunnable::ClearSignals()
-{
-	Super::ClearSignals();
-
-	if (!IsSpeechRecognizerValid())
-	{
-		return;
-	}
-	
-	SignalDisconnecter_T(SpeechRecognizer->Recognizing);
-	SignalDisconnecter_T(SpeechRecognizer->Recognized);
-}
-
-void FAzSpeechRecognitionRunnable::RemoveBindings()
-{
-	Super::RemoveBindings();
-	
-	UAzSpeechRecognizerTaskBase* const RecognizerTask = GetOwningRecognizerTask();
-
-	if (!UAzSpeechTaskStatus::IsTaskStillValid(RecognizerTask))
-	{
-		return;
-	}
-
-	DelegateDisconnecter_T(RecognizerTask->RecognitionStarted);
-	DelegateDisconnecter_T(RecognizerTask->RecognitionUpdated);
-	DelegateDisconnecter_T(RecognizerTask->RecognitionFailed);
 }
 
 const bool FAzSpeechRecognitionRunnable::ApplySDKSettings(const std::shared_ptr<Microsoft::CognitiveServices::Speech::SpeechConfig>& InConfig) const

--- a/Source/AzSpeech/Private/AzSpeech/Runnables/AzSpeechRecognitionRunnable.cpp
+++ b/Source/AzSpeech/Private/AzSpeech/Runnables/AzSpeechRecognitionRunnable.cpp
@@ -212,12 +212,7 @@ bool FAzSpeechRecognitionRunnable::ConnectRecognitionSignals()
 			}
 			else
 			{
-				AsyncTask(ENamedThreads::GameThread, 
-					[RecognizerTask, TaskResult = RecognitionEventArgs.Result] 
-					{
-						RecognizerTask->OnRecognitionUpdated(TaskResult); 
-					}
-				);
+				RecognizerTask->OnRecognitionUpdated(RecognitionEventArgs.Result);
 			}
 		}
 	);
@@ -243,13 +238,8 @@ bool FAzSpeechRecognitionRunnable::ConnectRecognitionSignals()
 			}
 			else
 			{
-				AsyncTask(ENamedThreads::GameThread, 
-					[RecognizerTask, TaskResult = RecognitionEventArgs.Result] 
-					{
-						RecognizerTask->OnRecognitionUpdated(TaskResult); 
-						RecognizerTask->BroadcastFinalResult();
-					}
-				);
+				RecognizerTask->OnRecognitionUpdated(RecognitionEventArgs.Result);
+				RecognizerTask->BroadcastFinalResult();
 			}
 
 			StopAzSpeechRunnableTask();

--- a/Source/AzSpeech/Private/AzSpeech/Runnables/AzSpeechRecognitionRunnable.cpp
+++ b/Source/AzSpeech/Private/AzSpeech/Runnables/AzSpeechRecognitionRunnable.cpp
@@ -19,8 +19,6 @@ FAzSpeechRecognitionRunnable::FAzSpeechRecognitionRunnable(UAzSpeechTaskBase* In
 
 uint32 FAzSpeechRecognitionRunnable::Run()
 {
-	FScopeLock Lock(&Mutex);
-
 #if !UE_BUILD_SHIPPING
 	const int64 StartTime = GetTimeInMilliseconds();
 #endif
@@ -59,11 +57,7 @@ uint32 FAzSpeechRecognitionRunnable::Run()
 	
 	if (RecognizerTask->RecognitionStarted.IsBound())
 	{
-		AsyncTask(ENamedThreads::GameThread, [RecognizerTask] 
-		{ 
-			RecognizerTask->RecognitionStarted.Broadcast();
-			RecognizerTask->RecognitionStarted.Clear();
-		});
+		AsyncTask(ENamedThreads::GameThread, [RecognizerTask] { RecognizerTask->RecognitionStarted.Broadcast(); });
 	}
 
 #if !UE_BUILD_SHIPPING
@@ -74,10 +68,11 @@ uint32 FAzSpeechRecognitionRunnable::Run()
 	
 	while (!IsPendingStop())
 	{
+		FPlatformProcess::Sleep(SleepTime);
+
 #if !UE_BUILD_SHIPPING
 		PrintDebugInformation(StartTime, ActivationDelay, SleepTime);
 #endif
-		FPlatformProcess::Sleep(SleepTime);
 	}
 	
 	return 1u;
@@ -85,8 +80,6 @@ uint32 FAzSpeechRecognitionRunnable::Run()
 
 void FAzSpeechRecognitionRunnable::Exit()
 {
-	FScopeLock Lock(&Mutex);
-
 	Super::Exit();
 
 	if (SpeechRecognizer)
@@ -119,8 +112,6 @@ UAzSpeechRecognizerTaskBase* FAzSpeechRecognitionRunnable::GetOwningRecognizerTa
 
 void FAzSpeechRecognitionRunnable::ClearSignals()
 {
-	FScopeLock Lock(&Mutex);
-
 	Super::ClearSignals();
 
 	if (!IsSpeechRecognizerValid())
@@ -134,8 +125,6 @@ void FAzSpeechRecognitionRunnable::ClearSignals()
 
 void FAzSpeechRecognitionRunnable::RemoveBindings()
 {
-	FScopeLock Lock(&Mutex);
-
 	Super::RemoveBindings();
 	
 	UAzSpeechRecognizerTaskBase* const RecognizerTask = GetOwningRecognizerTask();
@@ -147,12 +136,11 @@ void FAzSpeechRecognitionRunnable::RemoveBindings()
 
 	DelegateDisconnecter_T(RecognizerTask->RecognitionStarted);
 	DelegateDisconnecter_T(RecognizerTask->RecognitionUpdated);
+	DelegateDisconnecter_T(RecognizerTask->RecognitionFailed);
 }
 
 const bool FAzSpeechRecognitionRunnable::ApplySDKSettings(const std::shared_ptr<Microsoft::CognitiveServices::Speech::SpeechConfig>& InConfig) const
 {
-	FScopeLock Lock(&Mutex);
-
 	if (!Super::ApplySDKSettings(InConfig))
 	{
 		return false;
@@ -181,8 +169,6 @@ const bool FAzSpeechRecognitionRunnable::ApplySDKSettings(const std::shared_ptr<
 
 bool FAzSpeechRecognitionRunnable::InitializeAzureObject()
 {
-	FScopeLock Lock(&Mutex);
-
 	if (!Super::InitializeAzureObject())
 	{
 		return false;
@@ -229,41 +215,54 @@ bool FAzSpeechRecognitionRunnable::InitializeAzureObject()
 
 bool FAzSpeechRecognitionRunnable::ConnectRecognitionSignals()
 {
-	FScopeLock Lock(&Mutex);
-
 	UAzSpeechRecognizerTaskBase* const RecognizerTask = GetOwningRecognizerTask();
 	if (!IsSpeechRecognizerValid() || !UAzSpeechTaskStatus::IsTaskStillValid(RecognizerTask))
 	{
 		return false;
 	}
-	
-	const auto RecognitionUpdate_Lambda = [this, RecognizerTask](const Microsoft::CognitiveServices::Speech::SpeechRecognitionEventArgs& RecognitionEventArgs)
-	{
-		const bool bValidResult = ProcessRecognitionResult(RecognitionEventArgs.Result);
-		if (!UAzSpeechTaskStatus::IsTaskStillValid(RecognizerTask) || !bValidResult)
+
+	SpeechRecognizer->Recognizing.Connect(
+		[this, RecognizerTask](const Microsoft::CognitiveServices::Speech::SpeechRecognitionEventArgs& RecognitionEventArgs)
 		{
-			if (!bValidResult)
+			if (!UAzSpeechTaskStatus::IsTaskStillValid(RecognizerTask))
+			{
+				StopAzSpeechRunnableTask();
+			}
+			else
+			{
+				AsyncTask(ENamedThreads::GameThread, [RecognizerTask, TaskResult = RecognitionEventArgs.Result] { RecognizerTask->OnRecognitionUpdated(TaskResult); });
+			}
+		}
+	);
+
+	SpeechRecognizer->Recognized.Connect(
+		[this, RecognizerTask](const Microsoft::CognitiveServices::Speech::SpeechRecognitionEventArgs& RecognitionEventArgs)
+		{
+			const bool bValidResult = ProcessRecognitionResult(RecognitionEventArgs.Result);
+			if (!UAzSpeechTaskStatus::IsTaskStillValid(RecognizerTask) || !bValidResult)
 			{
 				AsyncTask(ENamedThreads::GameThread, [RecognizerTask] { RecognizerTask->RecognitionFailed.Broadcast(); });
 			}
+			else
+			{
+				AsyncTask(ENamedThreads::GameThread, 
+					[RecognizerTask, TaskResult = RecognitionEventArgs.Result] 
+					{ 
+						RecognizerTask->OnRecognitionUpdated(TaskResult); 
+						RecognizerTask->BroadcastFinalResult();
+					}
+				);
+			}
 
 			StopAzSpeechRunnableTask();
-			return;
 		}
-		
-		AsyncTask(ENamedThreads::GameThread, [RecognizerTask, TaskResult = RecognitionEventArgs.Result] { RecognizerTask->OnRecognitionUpdated(TaskResult); });
-	};
-
-	SpeechRecognizer->Recognized.Connect(RecognitionUpdate_Lambda);
-	SpeechRecognizer->Recognizing.Connect(RecognitionUpdate_Lambda);
+	);
 	
 	return true;
 }
 
 bool FAzSpeechRecognitionRunnable::InsertPhraseList() const
 {
-	FScopeLock Lock(&Mutex);
-
 	UAzSpeechRecognizerTaskBase* const RecognizerTask = GetOwningRecognizerTask();
 	if (!IsSpeechRecognizerValid() || !UAzSpeechTaskStatus::IsTaskStillValid(RecognizerTask))
 	{
@@ -298,26 +297,20 @@ bool FAzSpeechRecognitionRunnable::InsertPhraseList() const
 bool FAzSpeechRecognitionRunnable::ProcessRecognitionResult(const std::shared_ptr<Microsoft::CognitiveServices::Speech::SpeechRecognitionResult>& LastResult)
 {
 	bool bOutput = true;
-	bool bFinishTask = false;
 
 	switch (LastResult->Reason)
 	{
 		case Microsoft::CognitiveServices::Speech::ResultReason::RecognizingSpeech:
 			UE_LOG(LogAzSpeech_Internal, Display, TEXT("Thread: %s; Function: %s; Message: Task running. Reason: RecognizingSpeech"), *GetThreadName(), *FString(__func__));
-			bOutput = true;
-			bFinishTask = false;
 			break;
 
 		case Microsoft::CognitiveServices::Speech::ResultReason::RecognizedSpeech:
 			UE_LOG(LogAzSpeech_Internal, Display, TEXT("Thread: %s; Function: %s; Message: Task completed. Reason: RecognizedSpeech"), *GetThreadName(), *FString(__func__));
-			bOutput = true;
-			bFinishTask = true;
 			break;
 
 		case Microsoft::CognitiveServices::Speech::ResultReason::NoMatch:
 			UE_LOG(LogAzSpeech_Internal, Error, TEXT("Thread: %s; Function: %s; Message: Task failed. Reason: NoMatch"), *GetThreadName(), *FString(__func__));
 			bOutput = false;
-			bFinishTask = true;
 			break;
 
 		default:
@@ -327,7 +320,6 @@ bool FAzSpeechRecognitionRunnable::ProcessRecognitionResult(const std::shared_pt
 	if (LastResult->Reason == Microsoft::CognitiveServices::Speech::ResultReason::Canceled)
 	{
 		bOutput = false;
-		bFinishTask = true;
 
 		UE_LOG(LogAzSpeech_Internal, Error, TEXT("Thread: %s; Function: %s; Message: Task failed. Reason: Canceled"), *GetThreadName(), *FString(__func__));
 
@@ -339,11 +331,6 @@ bool FAzSpeechRecognitionRunnable::ProcessRecognitionResult(const std::shared_pt
 		{
 			ProcessCancellationError(CancellationDetails->ErrorCode, CancellationDetails->ErrorDetails);
 		}
-	}
-
-	if (bFinishTask)
-	{
-		StopAzSpeechRunnableTask();
 	}
 
 	return bOutput;

--- a/Source/AzSpeech/Private/AzSpeech/Runnables/AzSpeechRecognitionRunnable.cpp
+++ b/Source/AzSpeech/Private/AzSpeech/Runnables/AzSpeechRecognitionRunnable.cpp
@@ -203,7 +203,13 @@ bool FAzSpeechRecognitionRunnable::ConnectRecognitionSignals()
 			}
 			else
 			{
-				AsyncTask(ENamedThreads::GameThread, [RecognizerTask, TaskResult = RecognitionEventArgs.Result] { RecognizerTask->OnRecognitionUpdated(TaskResult); });
+				AsyncTask(ENamedThreads::GameThread, 
+					[RecognizerTask, TaskResult = RecognitionEventArgs.Result] 
+					{
+						FScopeLock Lock(&RecognizerTask->Mutex);
+						RecognizerTask->OnRecognitionUpdated(TaskResult); 
+					}
+				);
 			}
 		}
 	);
@@ -220,7 +226,8 @@ bool FAzSpeechRecognitionRunnable::ConnectRecognitionSignals()
 			{
 				AsyncTask(ENamedThreads::GameThread, 
 					[RecognizerTask, TaskResult = RecognitionEventArgs.Result] 
-					{ 
+					{
+						FScopeLock Lock(&RecognizerTask->Mutex);
 						RecognizerTask->OnRecognitionUpdated(TaskResult); 
 						RecognizerTask->BroadcastFinalResult();
 					}

--- a/Source/AzSpeech/Private/AzSpeech/Runnables/AzSpeechSynthesisRunnable.cpp
+++ b/Source/AzSpeech/Private/AzSpeech/Runnables/AzSpeechSynthesisRunnable.cpp
@@ -221,7 +221,13 @@ bool FAzSpeechSynthesisRunnable::ConnectVisemeSignal()
 			LastVisemeData.AudioOffsetMilliseconds = VisemeEventArgs.AudioOffset / 10000;
 			LastVisemeData.Animation = UTF8_TO_TCHAR(VisemeEventArgs.Animation.c_str());
 
-			AsyncTask(ENamedThreads::GameThread, [SynthesizerTask, LastVisemeData] { SynthesizerTask->OnVisemeReceived(LastVisemeData); });
+			AsyncTask(ENamedThreads::GameThread, 
+				[SynthesizerTask, LastVisemeData] 
+				{
+					FScopeLock Lock(&SynthesizerTask->Mutex);
+					SynthesizerTask->OnVisemeReceived(LastVisemeData); 
+				}
+			);
 		}
 	);
 
@@ -270,7 +276,13 @@ bool FAzSpeechSynthesisRunnable::ConnectSynthesisUpdateSignals()
 			}
 			else
 			{
-				AsyncTask(ENamedThreads::GameThread, [SynthesizerTask, Result = SynthesisEventArgs.Result] { SynthesizerTask->OnSynthesisUpdate(Result); });
+				AsyncTask(ENamedThreads::GameThread, 
+					[SynthesizerTask, Result = SynthesisEventArgs.Result] 
+					{
+						FScopeLock Lock(&SynthesizerTask->Mutex);
+						SynthesizerTask->OnSynthesisUpdate(Result); 
+					}
+				);
 			}
 		}
 	);
@@ -286,7 +298,8 @@ bool FAzSpeechSynthesisRunnable::ConnectSynthesisUpdateSignals()
 		{
 			AsyncTask(ENamedThreads::GameThread, 
 				[SynthesizerTask, Result = SynthesisEventArgs.Result]
-				{ 
+				{
+					FScopeLock Lock(&SynthesizerTask->Mutex);
 					SynthesizerTask->OnSynthesisUpdate(Result);
 					SynthesizerTask->BroadcastFinalResult(); 
 				}

--- a/Source/AzSpeech/Private/AzSpeech/Runnables/AzSpeechSynthesisRunnable.cpp
+++ b/Source/AzSpeech/Private/AzSpeech/Runnables/AzSpeechSynthesisRunnable.cpp
@@ -66,7 +66,7 @@ uint32 FAzSpeechSynthesisRunnable::Run()
 #endif
 
 	const float SleepTime = GetThreadUpdateInterval();
-	
+
 	while (!IsPendingStop())
 	{
 		FPlatformProcess::Sleep(SleepTime);
@@ -81,6 +81,8 @@ uint32 FAzSpeechSynthesisRunnable::Run()
 
 void FAzSpeechSynthesisRunnable::Exit()
 {
+	FScopeLock Lock(&Mutex);
+
 	Super::Exit();
 	
 	if (SpeechSynthesizer)
@@ -109,39 +111,6 @@ UAzSpeechSynthesizerTaskBase* FAzSpeechSynthesisRunnable::GetOwningSynthesizerTa
 	}
 
 	return Cast<UAzSpeechSynthesizerTaskBase>(GetOwningTask());
-}
-
-void FAzSpeechSynthesisRunnable::ClearSignals()
-{
-	Super::ClearSignals();
-	
-	if (!IsSpeechSynthesizerValid())
-	{
-		return;
-	}
-
-	SignalDisconnecter_T(SpeechSynthesizer->VisemeReceived);
-	SignalDisconnecter_T(SpeechSynthesizer->Synthesizing);
-	SignalDisconnecter_T(SpeechSynthesizer->SynthesisStarted);
-	SignalDisconnecter_T(SpeechSynthesizer->SynthesisCompleted);
-	SignalDisconnecter_T(SpeechSynthesizer->SynthesisCanceled);
-}
-
-void FAzSpeechSynthesisRunnable::RemoveBindings()
-{
-	Super::RemoveBindings();
-
-	UAzSpeechSynthesizerTaskBase* const SynthesizerTask = GetOwningSynthesizerTask();
-
-	if (!UAzSpeechTaskStatus::IsTaskStillValid(SynthesizerTask))
-	{
-		return;
-	}
-
-	DelegateDisconnecter_T(SynthesizerTask->VisemeReceived);
-	DelegateDisconnecter_T(SynthesizerTask->SynthesisUpdated);
-	DelegateDisconnecter_T(SynthesizerTask->SynthesisStarted);
-	DelegateDisconnecter_T(SynthesizerTask->SynthesisFailed);
 }
 
 const bool FAzSpeechSynthesisRunnable::ApplySDKSettings(const std::shared_ptr<Microsoft::CognitiveServices::Speech::SpeechConfig>& InConfig) const

--- a/Source/AzSpeech/Private/AzSpeech/Runnables/AzSpeechSynthesisRunnable.cpp
+++ b/Source/AzSpeech/Private/AzSpeech/Runnables/AzSpeechSynthesisRunnable.cpp
@@ -228,12 +228,7 @@ bool FAzSpeechSynthesisRunnable::ConnectVisemeSignal()
 			LastVisemeData.AudioOffsetMilliseconds = VisemeEventArgs.AudioOffset / 10000;
 			LastVisemeData.Animation = UTF8_TO_TCHAR(VisemeEventArgs.Animation.c_str());
 
-			AsyncTask(ENamedThreads::GameThread, 
-				[SynthesizerTask, LastVisemeData] 
-				{
-					SynthesizerTask->OnVisemeReceived(LastVisemeData); 
-				}
-			);
+			SynthesizerTask->OnVisemeReceived(LastVisemeData);
 		}
 	);
 
@@ -287,12 +282,7 @@ bool FAzSpeechSynthesisRunnable::ConnectSynthesisUpdateSignals()
 			}
 			else
 			{
-				AsyncTask(ENamedThreads::GameThread, 
-					[SynthesizerTask, Result = SynthesisEventArgs.Result] 
-					{
-						SynthesizerTask->OnSynthesisUpdate(Result); 
-					}
-				);
+				SynthesizerTask->OnSynthesisUpdate(SynthesisEventArgs.Result);
 			}
 		}
 	);
@@ -317,13 +307,8 @@ bool FAzSpeechSynthesisRunnable::ConnectSynthesisUpdateSignals()
 		}
 		else
 		{
-			AsyncTask(ENamedThreads::GameThread, 
-				[SynthesizerTask, Result = SynthesisEventArgs.Result]
-				{
-					SynthesizerTask->OnSynthesisUpdate(Result);
-					SynthesizerTask->BroadcastFinalResult(); 
-				}
-			);
+			SynthesizerTask->OnSynthesisUpdate(SynthesisEventArgs.Result);
+			SynthesizerTask->BroadcastFinalResult();
 		}
 
 		StopAzSpeechRunnableTask();

--- a/Source/AzSpeech/Private/AzSpeech/Runnables/Bases/AzSpeechRunnableBase.cpp
+++ b/Source/AzSpeech/Private/AzSpeech/Runnables/Bases/AzSpeechRunnableBase.cpp
@@ -71,13 +71,10 @@ void FAzSpeechRunnableBase::Exit()
 {
 	UE_LOG(LogAzSpeech_Internal, Display, TEXT("Thread: %s; Function: %s; Message: Exiting thread"), *GetThreadName(), *FString(__func__));
 
-	ClearSignals();
-
 	AsyncTask(ENamedThreads::GameThread, 
 		[this] 
 		{ 
 			GetOwningTask()->BroadcastFinalResult();
-			RemoveBindings();
 		}
 	);
 
@@ -133,16 +130,6 @@ bool FAzSpeechRunnableBase::CanInitializeTask() const
 	}
 
 	return bOutput;
-}
-
-void FAzSpeechRunnableBase::ClearSignals()
-{
-	UE_LOG(LogAzSpeech_Internal, Display, TEXT("Thread: %s; Function: %s; Message: Disconnecting Azure SDK recognition signals"), *GetThreadName(), *FString(__func__));
-}
-
-void FAzSpeechRunnableBase::RemoveBindings()
-{
-	UE_LOG(LogAzSpeech_Internal, Display, TEXT("Thread: %s; Function: %s; Message: Removing existing delegate bindings"), *GetThreadName(), *FString(__func__));
 }
 
 std::shared_ptr<Microsoft::CognitiveServices::Speech::SpeechConfig> FAzSpeechRunnableBase::CreateSpeechConfig() const

--- a/Source/AzSpeech/Private/AzSpeech/Runnables/Bases/AzSpeechRunnableBase.cpp
+++ b/Source/AzSpeech/Private/AzSpeech/Runnables/Bases/AzSpeechRunnableBase.cpp
@@ -73,13 +73,15 @@ void FAzSpeechRunnableBase::Exit()
 
 	AsyncTask(ENamedThreads::GameThread, 
 		[this] 
-		{ 
+		{
+			FScopeLock Lock(&GetOwningTask()->Mutex);
 			GetOwningTask()->BroadcastFinalResult();
 		}
 	);
 
 	if (UAzSpeechTaskStatus::IsTaskStillValid(GetOwningTask()) && !UAzSpeechTaskStatus::IsTaskReadyToDestroy(GetOwningTask()))
 	{
+		FScopeLock Lock(&GetOwningTask()->Mutex);
 		GetOwningTask()->SetReadyToDestroy();
 	}
 }

--- a/Source/AzSpeech/Private/AzSpeech/Runnables/Bases/AzSpeechRunnableBase.cpp
+++ b/Source/AzSpeech/Private/AzSpeech/Runnables/Bases/AzSpeechRunnableBase.cpp
@@ -78,17 +78,12 @@ void FAzSpeechRunnableBase::Exit()
 		return;
 	}
 
-	AsyncTask(ENamedThreads::GameThread,
-		[Task]
-		{
-			FScopeTryLock Lock(&Task->Mutex);
-			if (Lock.IsLocked())
-			{
-				Task->BroadcastFinalResult();
-				Task->SetReadyToDestroy();
-			}
-		}
-	);
+	FScopeTryLock Lock(&Task->Mutex);
+	if (Lock.IsLocked())
+	{
+		Task->BroadcastFinalResult();
+		Task->SetReadyToDestroy();
+	}
 }
 
 UAzSpeechTaskBase* FAzSpeechRunnableBase::GetOwningTask() const
@@ -323,10 +318,8 @@ void FAzSpeechRunnableBase::ProcessCancellationError(const Microsoft::CognitiveS
 			break;
 	}
 
-	UE_LOG(LogAzSpeech_Internal, Error, TEXT("Thread: %s; Function: %s; Message: Error code: %s"), *GetThreadName(), *FString(__func__), *ErrorCodeStr);
-	
-	UE_LOG(LogAzSpeech_Internal, Error, TEXT("Thread: %s; Function: %s; Message: Error Details: %s"), *GetThreadName(), *FString(__func__), *UTF8_TO_TCHAR(ErrorDetails.c_str()));
-	
+	UE_LOG(LogAzSpeech_Internal, Error, TEXT("Thread: %s; Function: %s; Message: Error code: %s"), *GetThreadName(), *FString(__func__), *ErrorCodeStr);	
+	UE_LOG(LogAzSpeech_Internal, Error, TEXT("Thread: %s; Function: %s; Message: Error Details: %s"), *GetThreadName(), *FString(__func__), *UTF8_TO_TCHAR(ErrorDetails.c_str()));	
 	UE_LOG(LogAzSpeech_Internal, Error, TEXT("Thread: %s; Function: %s; Message: Log generated in directory: %s"), *GetThreadName(), *FString(__func__), *UAzSpeechHelper::GetAzSpeechLogsBaseDir());
 }
 

--- a/Source/AzSpeech/Private/AzSpeech/Tasks/Bases/AzSpeechAudioDataSynthesisBase.cpp
+++ b/Source/AzSpeech/Private/AzSpeech/Tasks/Bases/AzSpeechAudioDataSynthesisBase.cpp
@@ -15,7 +15,7 @@ bool UAzSpeechAudioDataSynthesisBase::StartAzureTaskWork()
 		return false;
 	}
 	
-	if (HasEmptyParameters(SynthesisText))
+	if (AzSpeech::Internal::HasEmptyParam(SynthesisText))
 	{
 		return false;
 	}

--- a/Source/AzSpeech/Private/AzSpeech/Tasks/Bases/AzSpeechRecognizerTaskBase.cpp
+++ b/Source/AzSpeech/Private/AzSpeech/Tasks/Bases/AzSpeechRecognizerTaskBase.cpp
@@ -73,23 +73,5 @@ void UAzSpeechRecognizerTaskBase::OnRecognitionUpdated(const std::shared_ptr<Mic
 	UE_LOG(LogAzSpeech_Debugging, Display, TEXT("Task: %s (%d); Function: %s; Message: Current reason code: %d"), *TaskName.ToString(), GetUniqueID(), *FString(__func__), static_cast<int32>(LastResult->Reason));
 	UE_LOG(LogAzSpeech_Debugging, Display, TEXT("Task: %s (%d); Function: %s; Message: Current result id: %s"), *TaskName.ToString(), GetUniqueID(), *FString(__func__), UTF8_TO_TCHAR(LastResult->ResultId.c_str()));
 
-	if (LastResult->Reason == Microsoft::CognitiveServices::Speech::ResultReason::RecognizedSpeech)
-	{
-		UE_LOG(LogAzSpeech_Internal, Display, TEXT("Task: %s (%d); Function: %s; Message: Task completed with result: %s"), *TaskName.ToString(), GetUniqueID(), *FString(__func__), *GetRecognizedString());
-		BroadcastFinalResult();
-	}
-
-	switch (LastResult->Reason)
-	{
-		case Microsoft::CognitiveServices::Speech::ResultReason::RecognizedSpeech:
-		case Microsoft::CognitiveServices::Speech::ResultReason::RecognizingSpeech:
-			if (RecognitionUpdated.IsBound())
-			{
-				RecognitionUpdated.Broadcast(GetRecognizedString());
-			}
-
-			break;
-
-		default: break;
-	}
+	RecognitionUpdated.Broadcast(GetRecognizedString());
 }

--- a/Source/AzSpeech/Private/AzSpeech/Tasks/Bases/AzSpeechRecognizerTaskBase.cpp
+++ b/Source/AzSpeech/Private/AzSpeech/Tasks/Bases/AzSpeechRecognizerTaskBase.cpp
@@ -37,15 +37,16 @@ void UAzSpeechRecognizerTaskBase::StartRecognitionWork(const std::shared_ptr<Mic
 
 void UAzSpeechRecognizerTaskBase::BroadcastFinalResult()
 {
+	FScopeLock Lock(&Mutex);
+
+	if (!UAzSpeechTaskStatus::IsTaskActive(this))
+	{
+		return;
+	}
+
 	Super::BroadcastFinalResult();
 
-	FScopeLock Lock(&Mutex);
-	
-	if (RecognitionCompleted.IsBound())
-	{
-		RecognitionCompleted.Broadcast(GetRecognizedString());
-		RecognitionCompleted.Clear();
-	}
+	RecognitionCompleted.Broadcast(GetRecognizedString());
 }
 
 void UAzSpeechRecognizerTaskBase::OnRecognitionUpdated(const std::shared_ptr<Microsoft::CognitiveServices::Speech::SpeechRecognitionResult>& LastResult)

--- a/Source/AzSpeech/Private/AzSpeech/Tasks/Bases/AzSpeechRecognizerTaskBase.cpp
+++ b/Source/AzSpeech/Private/AzSpeech/Tasks/Bases/AzSpeechRecognizerTaskBase.cpp
@@ -51,19 +51,9 @@ void UAzSpeechRecognizerTaskBase::BroadcastFinalResult()
 
 void UAzSpeechRecognizerTaskBase::OnRecognitionUpdated(const std::shared_ptr<Microsoft::CognitiveServices::Speech::SpeechRecognitionResult>& LastResult)
 {
-	check(IsInGameThread());
-
-	if (!UAzSpeechTaskStatus::IsTaskStillValid(this) || !LastResult)
-	{
-		if (!UAzSpeechTaskStatus::IsTaskReadyToDestroy(this))
-		{
-			SetReadyToDestroy();
-		}
-
-		return;
-	}
-	
 	FScopeLock Lock(&Mutex);
+
+	check(IsInGameThread());
 
 	RecognizedText = LastResult->Text;
 

--- a/Source/AzSpeech/Private/AzSpeech/Tasks/Bases/AzSpeechSpeechSynthesisBase.cpp
+++ b/Source/AzSpeech/Private/AzSpeech/Tasks/Bases/AzSpeechSpeechSynthesisBase.cpp
@@ -62,30 +62,6 @@ void UAzSpeechSpeechSynthesisBase::BroadcastFinalResult()
 	AudioComponent->Play();
 }
 
-void UAzSpeechSpeechSynthesisBase::OnSynthesisUpdate(const std::shared_ptr<Microsoft::CognitiveServices::Speech::SpeechSynthesisResult>& LastResult)
-{	
-	Super::OnSynthesisUpdate(LastResult);
-
-	if (!UAzSpeechTaskStatus::IsTaskStillValid(this))
-	{
-		return;
-	}
-
-	if (CanBroadcastWithReason(LastResult->Reason))
-	{
-		FScopeLock Lock(&Mutex);
-
-		const TArray<uint8> LastBuffer = GetAudioData();
-		if (!UAzSpeechHelper::IsAudioDataValid(LastBuffer))
-		{
-			SetReadyToDestroy();
-			return;
-		}
-
-		BroadcastFinalResult();
-	}
-}
-
 void UAzSpeechSpeechSynthesisBase::OnAudioPlayStateChanged(const EAudioComponentPlayState PlayState)
 {
 	if (!UAzSpeechTaskStatus::IsTaskStillValid(this))

--- a/Source/AzSpeech/Private/AzSpeech/Tasks/Bases/AzSpeechSynthesizerTaskBase.cpp
+++ b/Source/AzSpeech/Private/AzSpeech/Tasks/Bases/AzSpeechSynthesizerTaskBase.cpp
@@ -19,7 +19,7 @@ void UAzSpeechSynthesizerTaskBase::Activate()
 	Super::Activate();
 }
 
-const FAzSpeechVisemeData UAzSpeechSynthesizerTaskBase::GetVisemeData() const
+const FAzSpeechVisemeData& UAzSpeechSynthesizerTaskBase::GetLastVisemeData() const
 {
 	FScopeLock Lock(&Mutex);
 

--- a/Source/AzSpeech/Private/AzSpeech/Tasks/Bases/AzSpeechSynthesizerTaskBase.cpp
+++ b/Source/AzSpeech/Private/AzSpeech/Tasks/Bases/AzSpeechSynthesizerTaskBase.cpp
@@ -45,10 +45,7 @@ const TArray<uint8> UAzSpeechSynthesizerTaskBase::GetAudioData() const
 	}
 
 	TArray<uint8> OutputArr;
-	for (const uint8_t& i : AudioData)
-	{
-		OutputArr.Add(static_cast<uint8>(i));
-	}
+	OutputArr.Append(reinterpret_cast<const uint8*>(AudioData.data()), AudioData.size());
 
 	return OutputArr;
 }
@@ -103,11 +100,7 @@ void UAzSpeechSynthesizerTaskBase::OnVisemeReceived(const FAzSpeechVisemeData& V
 	FScopeLock Lock(&Mutex);
 
 	VisemeDataArray.Add(VisemeData);
-
-	if (VisemeReceived.IsBound())
-	{
-		VisemeReceived.Broadcast(VisemeData);
-	}
+	VisemeReceived.Broadcast(VisemeData);
 
 	UE_LOG(LogAzSpeech_Debugging, Display, TEXT("Task: %s (%d); Function: %s; Message: Current Viseme Id: %d"), *TaskName.ToString(), GetUniqueID(), *FString(__func__), VisemeData.VisemeID);
 	UE_LOG(LogAzSpeech_Debugging, Display, TEXT("Task: %s (%d); Function: %s; Message: Current Viseme Audio Offset: %dms"), *TaskName.ToString(), GetUniqueID(), *FString(__func__), VisemeData.AudioOffsetMilliseconds);
@@ -175,7 +168,7 @@ void UAzSpeechSynthesizerTaskBase::ValidateVoiceName()
 	}
 
 	const auto Settings = UAzSpeechSettings::GetAzSpeechKeys();
-	if (HasEmptyParameters(VoiceName) || VoiceName.Equals("Default", ESearchCase::IgnoreCase))
+	if (AzSpeech::Internal::HasEmptyParam(VoiceName) || VoiceName.Equals("Default", ESearchCase::IgnoreCase))
 	{
 		VoiceName = UTF8_TO_TCHAR(Settings.at(3).c_str());
 	}

--- a/Source/AzSpeech/Private/AzSpeech/Tasks/Bases/AzSpeechSynthesizerTaskBase.cpp
+++ b/Source/AzSpeech/Private/AzSpeech/Tasks/Bases/AzSpeechSynthesizerTaskBase.cpp
@@ -21,6 +21,8 @@ void UAzSpeechSynthesizerTaskBase::Activate()
 
 const FAzSpeechVisemeData UAzSpeechSynthesizerTaskBase::GetVisemeData() const
 {
+	FScopeLock Lock(&Mutex);
+
 	if (AzSpeech::Internal::HasEmptyParam(VisemeDataArray))
 	{
 		UE_LOG(LogAzSpeech_Internal, Error, TEXT("Task: %s (%d); Function: %s; Message: Viseme data is empty"), *TaskName.ToString(), GetUniqueID(), *FString(__func__));
@@ -32,6 +34,8 @@ const FAzSpeechVisemeData UAzSpeechSynthesizerTaskBase::GetVisemeData() const
 
 const TArray<FAzSpeechVisemeData> UAzSpeechSynthesizerTaskBase::GetVisemeDataArray() const
 {
+	FScopeLock Lock(&Mutex);
+
 	return VisemeDataArray;
 }
 
@@ -52,21 +56,29 @@ const TArray<uint8> UAzSpeechSynthesizerTaskBase::GetAudioData() const
 
 const bool UAzSpeechSynthesizerTaskBase::IsLastResultValid() const
 {
+	FScopeLock Lock(&Mutex);
+
 	return bLastResultIsValid;
 }
 
 const FString UAzSpeechSynthesizerTaskBase::GetVoiceName() const
 {
+	FScopeLock Lock(&Mutex);
+
 	return VoiceName;
 }
 
 const FString UAzSpeechSynthesizerTaskBase::GetSynthesisText() const
 {
+	FScopeLock Lock(&Mutex);
+
 	return SynthesisText;
 }
 
 const bool UAzSpeechSynthesizerTaskBase::IsSSMLBased() const
 {
+	FScopeLock Lock(&Mutex);
+
 	return bIsSSMLBased;
 }
 
@@ -133,6 +145,8 @@ void UAzSpeechSynthesizerTaskBase::OnSynthesisUpdate(const std::shared_ptr<Micro
 
 void UAzSpeechSynthesizerTaskBase::ValidateVoiceName()
 {
+	FScopeLock Lock(&Mutex);
+
 	if (bIsSSMLBased)
 	{
 		return;

--- a/Source/AzSpeech/Private/AzSpeech/Tasks/Bases/AzSpeechSynthesizerTaskBase.cpp
+++ b/Source/AzSpeech/Private/AzSpeech/Tasks/Bases/AzSpeechSynthesizerTaskBase.cpp
@@ -22,6 +22,8 @@ void UAzSpeechSynthesizerTaskBase::Activate()
 
 const FAzSpeechVisemeData UAzSpeechSynthesizerTaskBase::GetLastVisemeData() const
 {
+	FScopeLock Lock(&Mutex);
+
 	if (AzSpeech::Internal::HasEmptyParam(VisemeDataArray))
 	{
 		UE_LOG(LogAzSpeech_Internal, Error, TEXT("Task: %s (%d); Function: %s; Message: Viseme data is empty"), *TaskName.ToString(), GetUniqueID(), *FString(__func__));
@@ -38,6 +40,8 @@ const TArray<FAzSpeechVisemeData> UAzSpeechSynthesizerTaskBase::GetVisemeDataArr
 
 const TArray<uint8> UAzSpeechSynthesizerTaskBase::GetAudioData() const
 {
+	FScopeLock Lock(&Mutex);
+
 	if (AudioData.empty())
 	{
 		return TArray<uint8>();

--- a/Source/AzSpeech/Private/AzSpeech/Tasks/Bases/AzSpeechSynthesizerTaskBase.cpp
+++ b/Source/AzSpeech/Private/AzSpeech/Tasks/Bases/AzSpeechSynthesizerTaskBase.cpp
@@ -97,14 +97,9 @@ void UAzSpeechSynthesizerTaskBase::StartSynthesisWork(const std::shared_ptr<Micr
 
 void UAzSpeechSynthesizerTaskBase::OnVisemeReceived(const FAzSpeechVisemeData& VisemeData)
 {
-	check(IsInGameThread());
-
-	if (!UAzSpeechTaskStatus::IsTaskStillValid(this))
-	{
-		return;
-	}
-
 	FScopeLock Lock(&Mutex);
+
+	check(IsInGameThread());
 
 	VisemeDataArray.Add(VisemeData);
 	VisemeReceived.Broadcast(VisemeData);
@@ -116,22 +111,11 @@ void UAzSpeechSynthesizerTaskBase::OnVisemeReceived(const FAzSpeechVisemeData& V
 
 void UAzSpeechSynthesizerTaskBase::OnSynthesisUpdate(const std::shared_ptr<Microsoft::CognitiveServices::Speech::SpeechSynthesisResult>& LastResult)
 {
-	check(IsInGameThread());
-
-	if (!UAzSpeechTaskStatus::IsTaskStillValid(this) || !LastResult)
-	{
-		if (!UAzSpeechTaskStatus::IsTaskReadyToDestroy(this))
-		{
-			SetReadyToDestroy();
-		}
-
-		return;
-	}
-
 	FScopeLock Lock(&Mutex);
 
-	AudioData = *LastResult->GetAudioData().get();
+	check(IsInGameThread());
 
+	AudioData = *LastResult->GetAudioData().get();
 	bLastResultIsValid = !AudioData.empty();
 
 	UE_LOG(LogAzSpeech_Debugging, Display, TEXT("Task: %s (%d); Function: %s; Message: Current audio duration: %d"), *TaskName.ToString(), GetUniqueID(), *FString(__func__), LastResult->AudioDuration.count());

--- a/Source/AzSpeech/Private/AzSpeech/Tasks/Bases/AzSpeechTaskBase.cpp
+++ b/Source/AzSpeech/Private/AzSpeech/Tasks/Bases/AzSpeechTaskBase.cpp
@@ -63,8 +63,6 @@ void UAzSpeechTaskBase::StopAzSpeechTask()
 	{
 		RunnableTask->StopAzSpeechRunnableTask();
 	}
-
-	BroadcastFinalResult();
 	
 	SetReadyToDestroy();
 }
@@ -121,6 +119,11 @@ bool UAzSpeechTaskBase::StartAzureTaskWork()
 void UAzSpeechTaskBase::BroadcastFinalResult()
 {
 	check(IsInGameThread());
+
+	if (!bIsTaskActive)
+	{
+		return;
+	}
 	
 	UE_LOG(LogAzSpeech_Internal, Display, TEXT("Task: %s (%d); Function: %s; Message: Task completed, broadcasting final result"), *TaskName.ToString(), GetUniqueID(), *FString(__func__));
 
@@ -150,7 +153,7 @@ void UAzSpeechTaskBase::ValidateLanguageID()
 	}
 
 	const auto Settings = UAzSpeechSettings::GetAzSpeechKeys();
-	if (HasEmptyParameters(LanguageID) || LanguageID.Equals("Default", ESearchCase::IgnoreCase))
+	if (AzSpeech::Internal::HasEmptyParam(LanguageID) || LanguageID.Equals("Default", ESearchCase::IgnoreCase))
 	{
 		LanguageID = UTF8_TO_TCHAR(Settings.at(2).c_str());
 	}

--- a/Source/AzSpeech/Private/AzSpeech/Tasks/Bases/AzSpeechTaskBase.cpp
+++ b/Source/AzSpeech/Private/AzSpeech/Tasks/Bases/AzSpeechTaskBase.cpp
@@ -49,12 +49,12 @@ void UAzSpeechTaskBase::Activate()
 
 void UAzSpeechTaskBase::StopAzSpeechTask()
 {
+	FScopeLock Lock(&Mutex);
+
 	if (!UAzSpeechTaskStatus::IsTaskActive(this) || UAzSpeechTaskStatus::IsTaskReadyToDestroy(this))
 	{
 		return;
 	}
-
-	FScopeLock Lock(&Mutex);
 
 	UE_LOG(LogAzSpeech, Display, TEXT("Task: %s (%d); Function: %s; Message: Stopping task"), *TaskName.ToString(), GetUniqueID(), *FString(__func__));
 	bIsTaskActive = false;
@@ -69,33 +69,27 @@ void UAzSpeechTaskBase::StopAzSpeechTask()
 
 const bool UAzSpeechTaskBase::IsUsingAutoLanguage() const
 {
-	FScopeLock Lock(&Mutex);
-
 	return LanguageID.Equals("Auto", ESearchCase::IgnoreCase);
 }
 
 const FString UAzSpeechTaskBase::GetTaskName() const
 {
-	FScopeLock Lock(&Mutex);
-
 	return TaskName.ToString();
 }
 
 const FString UAzSpeechTaskBase::GetLanguageID() const
 {
-	FScopeLock Lock(&Mutex);
-
 	return LanguageID;
 }
 
 void UAzSpeechTaskBase::SetReadyToDestroy()
 {
+	FScopeLock Lock(&Mutex);
+
 	if (UAzSpeechTaskStatus::IsTaskReadyToDestroy(this))
 	{
 		return;
 	}
-
-	FScopeLock Lock(&Mutex);
 
 	UE_LOG(LogAzSpeech, Display, TEXT("Task: %s (%d); Function: %s; Message: Setting task as Ready to Destroy"), *TaskName.ToString(), GetUniqueID(), *FString(__func__));
 	bIsReadyToDestroy = true;
@@ -124,7 +118,7 @@ bool UAzSpeechTaskBase::StartAzureTaskWork()
 
 void UAzSpeechTaskBase::BroadcastFinalResult()
 {
-	check(IsInGameThread());
+	FScopeLock Lock(&Mutex);
 
 	if (!bIsTaskActive)
 	{

--- a/Source/AzSpeech/Private/AzSpeech/Tasks/Bases/AzSpeechTaskBase.cpp
+++ b/Source/AzSpeech/Private/AzSpeech/Tasks/Bases/AzSpeechTaskBase.cpp
@@ -69,16 +69,22 @@ void UAzSpeechTaskBase::StopAzSpeechTask()
 
 const bool UAzSpeechTaskBase::IsUsingAutoLanguage() const
 {
+	FScopeLock Lock(&Mutex);
+
 	return LanguageID.Equals("Auto", ESearchCase::IgnoreCase);
 }
 
 const FString UAzSpeechTaskBase::GetTaskName() const
 {
+	FScopeLock Lock(&Mutex);
+
 	return TaskName.ToString();
 }
 
 const FString UAzSpeechTaskBase::GetLanguageID() const
 {
+	FScopeLock Lock(&Mutex);
+
 	return LanguageID;
 }
 
@@ -147,6 +153,8 @@ void UAzSpeechTaskBase::PrePIEEnded(bool bIsSimulating)
 
 void UAzSpeechTaskBase::ValidateLanguageID()
 {
+	FScopeLock Lock(&Mutex);
+
 	if (bIsSSMLBased)
 	{
 		return;

--- a/Source/AzSpeech/Private/AzSpeech/Tasks/Bases/AzSpeechWavFileSynthesisBase.cpp
+++ b/Source/AzSpeech/Private/AzSpeech/Tasks/Bases/AzSpeechWavFileSynthesisBase.cpp
@@ -6,6 +6,7 @@
 #include "AzSpeech/AzSpeechHelper.h"
 #include "LogAzSpeech.h"
 #include <HAL/FileManager.h>
+#include <Async/Async.h>
 
 #ifdef UE_INLINE_GENERATED_CPP_BY_NAME
 #include UE_INLINE_GENERATED_CPP_BY_NAME(AzSpeechWavFileSynthesisBase)
@@ -29,11 +30,6 @@ void UAzSpeechWavFileSynthesisBase::SetReadyToDestroy()
 	if (UAzSpeechTaskStatus::IsTaskReadyToDestroy(this))
 	{
 		return;
-	}
-
-	if (SynthesisCompleted.IsBound())
-	{
-		SynthesisCompleted.Clear();;
 	}
 
 	Super::SetReadyToDestroy();
@@ -72,7 +68,12 @@ void UAzSpeechWavFileSynthesisBase::BroadcastFinalResult()
 
 	Super::BroadcastFinalResult();
 
-	SynthesisCompleted.Broadcast(IsLastResultValid() && UAzSpeechHelper::IsAudioDataValid(GetAudioData()));
+	AsyncTask(ENamedThreads::GameThread,
+		[this]
+		{
+			SynthesisCompleted.Broadcast(IsLastResultValid() && UAzSpeechHelper::IsAudioDataValid(GetAudioData()));
+		}
+	);
 }
 
 bool UAzSpeechWavFileSynthesisBase::StartAzureTaskWork()

--- a/Source/AzSpeech/Private/AzSpeech/Tasks/Bases/AzSpeechWavFileSynthesisBase.cpp
+++ b/Source/AzSpeech/Private/AzSpeech/Tasks/Bases/AzSpeechWavFileSynthesisBase.cpp
@@ -63,15 +63,16 @@ void UAzSpeechWavFileSynthesisBase::SetReadyToDestroy()
 
 void UAzSpeechWavFileSynthesisBase::BroadcastFinalResult()
 {
-	Super::BroadcastFinalResult();
-
 	FScopeLock Lock(&Mutex);
 
-	if (SynthesisCompleted.IsBound())
+	if (!UAzSpeechTaskStatus::IsTaskActive(this))
 	{
-		SynthesisCompleted.Broadcast(IsLastResultValid() && UAzSpeechHelper::IsAudioDataValid(GetAudioData()));
-		SynthesisCompleted.Clear();
+		return;
 	}
+
+	Super::BroadcastFinalResult();
+
+	SynthesisCompleted.Broadcast(IsLastResultValid() && UAzSpeechHelper::IsAudioDataValid(GetAudioData()));
 }
 
 bool UAzSpeechWavFileSynthesisBase::StartAzureTaskWork()
@@ -81,8 +82,7 @@ bool UAzSpeechWavFileSynthesisBase::StartAzureTaskWork()
 		return false;
 	}
 
-	if (HasEmptyParameters(SynthesisText, FilePath, FileName) ||
-		(!bIsSSMLBased && HasEmptyParameters(VoiceName, LanguageID)))
+	if (AzSpeech::Internal::HasEmptyParam(SynthesisText, FilePath, FileName) || (!bIsSSMLBased && AzSpeech::Internal::HasEmptyParam(VoiceName, LanguageID)))
 	{
 		return false;
 	}
@@ -96,21 +96,4 @@ bool UAzSpeechWavFileSynthesisBase::StartAzureTaskWork()
 	StartSynthesisWork(AudioConfig);
 
 	return true;
-}
-
-void UAzSpeechWavFileSynthesisBase::OnSynthesisUpdate(const std::shared_ptr<Microsoft::CognitiveServices::Speech::SpeechSynthesisResult>& LastResult)
-{
-	Super::OnSynthesisUpdate(LastResult);
-
-	if (!UAzSpeechTaskStatus::IsTaskStillValid(this))
-	{
-		return;
-	}
-
-	if (CanBroadcastWithReason(LastResult->Reason))
-	{
-		FScopeLock Lock(&Mutex);
-
-		BroadcastFinalResult();
-	}
 }

--- a/Source/AzSpeech/Private/AzSpeech/Tasks/SSMLToAudioDataAsync.cpp
+++ b/Source/AzSpeech/Private/AzSpeech/Tasks/SSMLToAudioDataAsync.cpp
@@ -3,6 +3,7 @@
 // Repo: https://github.com/lucoiso/UEAzSpeech
 
 #include "AzSpeech/Tasks/SSMLToAudioDataAsync.h"
+#include <Async/Async.h>
 
 #ifdef UE_INLINE_GENERATED_CPP_BY_NAME
 #include UE_INLINE_GENERATED_CPP_BY_NAME(SSMLToAudioDataAsync)
@@ -31,5 +32,10 @@ void USSMLToAudioDataAsync::BroadcastFinalResult()
 
 	Super::BroadcastFinalResult();
 
-	SynthesisCompleted.Broadcast(GetAudioData());
+	AsyncTask(ENamedThreads::GameThread,
+		[this]
+		{
+			SynthesisCompleted.Broadcast(GetAudioData());
+		}
+	);
 }

--- a/Source/AzSpeech/Private/AzSpeech/Tasks/SSMLToAudioDataAsync.cpp
+++ b/Source/AzSpeech/Private/AzSpeech/Tasks/SSMLToAudioDataAsync.cpp
@@ -22,30 +22,14 @@ USSMLToAudioDataAsync* USSMLToAudioDataAsync::SSMLToAudioData(UObject* WorldCont
 
 void USSMLToAudioDataAsync::BroadcastFinalResult()
 {
-	Super::BroadcastFinalResult();
-
 	FScopeLock Lock(&Mutex);
 
-	if (SynthesisCompleted.IsBound())
-	{
-		SynthesisCompleted.Broadcast(GetAudioData());
-		SynthesisCompleted.Clear();
-	}
-}
-
-void USSMLToAudioDataAsync::OnSynthesisUpdate(const std::shared_ptr<Microsoft::CognitiveServices::Speech::SpeechSynthesisResult>& LastResult)
-{
-	Super::OnSynthesisUpdate(LastResult);
-
-	if (!UAzSpeechTaskStatus::IsTaskStillValid(this))
+	if (!UAzSpeechTaskStatus::IsTaskActive(this))
 	{
 		return;
 	}
 
-	if (CanBroadcastWithReason(LastResult->Reason))
-	{
-		FScopeLock Lock(&Mutex);
+	Super::BroadcastFinalResult();
 
-		BroadcastFinalResult();
-	}
+	SynthesisCompleted.Broadcast(GetAudioData());
 }

--- a/Source/AzSpeech/Private/AzSpeech/Tasks/SSMLToSoundWaveAsync.cpp
+++ b/Source/AzSpeech/Private/AzSpeech/Tasks/SSMLToSoundWaveAsync.cpp
@@ -5,6 +5,7 @@
 #include "AzSpeech/Tasks/SSMLToSoundWaveAsync.h"
 #include "AzSpeech/AzSpeechHelper.h"
 #include <Sound/SoundWave.h>
+#include <Async/Async.h>
 
 #ifdef UE_INLINE_GENERATED_CPP_BY_NAME
 #include UE_INLINE_GENERATED_CPP_BY_NAME(SSMLToSoundWaveAsync)
@@ -33,6 +34,11 @@ void USSMLToSoundWaveAsync::BroadcastFinalResult()
 
 	Super::BroadcastFinalResult();
 
-	const TArray<uint8> LastBuffer = GetAudioData();
-	SynthesisCompleted.Broadcast(UAzSpeechHelper::ConvertAudioDataToSoundWave(LastBuffer));
+	AsyncTask(ENamedThreads::GameThread,
+		[this]
+		{
+			const TArray<uint8> LastBuffer = GetAudioData();
+			SynthesisCompleted.Broadcast(UAzSpeechHelper::ConvertAudioDataToSoundWave(LastBuffer));
+		}
+	);
 }

--- a/Source/AzSpeech/Private/AzSpeech/Tasks/SSMLToSoundWaveAsync.cpp
+++ b/Source/AzSpeech/Private/AzSpeech/Tasks/SSMLToSoundWaveAsync.cpp
@@ -24,31 +24,15 @@ USSMLToSoundWaveAsync* USSMLToSoundWaveAsync::SSMLToSoundWave(UObject* WorldCont
 
 void USSMLToSoundWaveAsync::BroadcastFinalResult()
 {
-	Super::BroadcastFinalResult();
-
 	FScopeLock Lock(&Mutex);
 
-	if (SynthesisCompleted.IsBound())
-	{
-		const TArray<uint8> LastBuffer = GetAudioData();
-		SynthesisCompleted.Broadcast(UAzSpeechHelper::ConvertAudioDataToSoundWave(LastBuffer));
-		SynthesisCompleted.Clear();
-	}
-}
-
-void USSMLToSoundWaveAsync::OnSynthesisUpdate(const std::shared_ptr<Microsoft::CognitiveServices::Speech::SpeechSynthesisResult>& LastResult)
-{
-	Super::OnSynthesisUpdate(LastResult);
-
-	if (!UAzSpeechTaskStatus::IsTaskStillValid(this))
+	if (!UAzSpeechTaskStatus::IsTaskActive(this))
 	{
 		return;
 	}
 
-	if (CanBroadcastWithReason(LastResult->Reason))
-	{
-		FScopeLock Lock(&Mutex);
+	Super::BroadcastFinalResult();
 
-		BroadcastFinalResult();
-	}
+	const TArray<uint8> LastBuffer = GetAudioData();
+	SynthesisCompleted.Broadcast(UAzSpeechHelper::ConvertAudioDataToSoundWave(LastBuffer));
 }

--- a/Source/AzSpeech/Private/AzSpeech/Tasks/SpeechToTextAsync.cpp
+++ b/Source/AzSpeech/Private/AzSpeech/Tasks/SpeechToTextAsync.cpp
@@ -38,7 +38,7 @@ void USpeechToTextAsync::Activate()
 
 bool USpeechToTextAsync::IsUsingDefaultAudioInputDevice() const
 {
-	return HasEmptyParameters(AudioInputDeviceID) || AudioInputDeviceID.Equals("Default", ESearchCase::IgnoreCase);
+	return AzSpeech::Internal::HasEmptyParam(AudioInputDeviceID) || AudioInputDeviceID.Equals("Default", ESearchCase::IgnoreCase);
 }
 
 bool USpeechToTextAsync::StartAzureTaskWork()
@@ -48,7 +48,7 @@ bool USpeechToTextAsync::StartAzureTaskWork()
 		return false;
 	}
 
-	if (HasEmptyParameters(LanguageID))
+	if (AzSpeech::Internal::HasEmptyParam(LanguageID))
 	{
 		return false;
 	}

--- a/Source/AzSpeech/Private/AzSpeech/Tasks/SpeechToTextAsync.cpp
+++ b/Source/AzSpeech/Private/AzSpeech/Tasks/SpeechToTextAsync.cpp
@@ -38,6 +38,8 @@ void USpeechToTextAsync::Activate()
 
 bool USpeechToTextAsync::IsUsingDefaultAudioInputDevice() const
 {
+	FScopeLock Lock(&Mutex);
+
 	return AzSpeech::Internal::HasEmptyParam(AudioInputDeviceID) || AudioInputDeviceID.Equals("Default", ESearchCase::IgnoreCase);
 }
 

--- a/Source/AzSpeech/Private/AzSpeech/Tasks/SpeechToTextAsync.cpp
+++ b/Source/AzSpeech/Private/AzSpeech/Tasks/SpeechToTextAsync.cpp
@@ -38,8 +38,6 @@ void USpeechToTextAsync::Activate()
 
 bool USpeechToTextAsync::IsUsingDefaultAudioInputDevice() const
 {
-	FScopeLock Lock(&Mutex);
-
 	return AzSpeech::Internal::HasEmptyParam(AudioInputDeviceID) || AudioInputDeviceID.Equals("Default", ESearchCase::IgnoreCase);
 }
 

--- a/Source/AzSpeech/Private/AzSpeech/Tasks/TextToAudioDataAsync.cpp
+++ b/Source/AzSpeech/Private/AzSpeech/Tasks/TextToAudioDataAsync.cpp
@@ -24,30 +24,14 @@ UTextToAudioDataAsync* UTextToAudioDataAsync::TextToAudioData(UObject* WorldCont
 
 void UTextToAudioDataAsync::BroadcastFinalResult()
 {
-	Super::BroadcastFinalResult();
-
 	FScopeLock Lock(&Mutex);
 
-	if (SynthesisCompleted.IsBound())
-	{
-		SynthesisCompleted.Broadcast(GetAudioData());
-		SynthesisCompleted.Clear();
-	}
-}
-
-void UTextToAudioDataAsync::OnSynthesisUpdate(const std::shared_ptr<Microsoft::CognitiveServices::Speech::SpeechSynthesisResult>& LastResult)
-{
-	Super::OnSynthesisUpdate(LastResult);
-
-	if (!UAzSpeechTaskStatus::IsTaskStillValid(this))
+	if (!UAzSpeechTaskStatus::IsTaskActive(this))
 	{
 		return;
 	}
 
-	if (CanBroadcastWithReason(LastResult->Reason))
-	{
-		FScopeLock Lock(&Mutex);
+	Super::BroadcastFinalResult();
 
-		BroadcastFinalResult();
-	}
+	SynthesisCompleted.Broadcast(GetAudioData());
 }

--- a/Source/AzSpeech/Private/AzSpeech/Tasks/TextToAudioDataAsync.cpp
+++ b/Source/AzSpeech/Private/AzSpeech/Tasks/TextToAudioDataAsync.cpp
@@ -3,6 +3,7 @@
 // Repo: https://github.com/lucoiso/UEAzSpeech
 
 #include "AzSpeech/Tasks/TextToAudioDataAsync.h"
+#include <Async/Async.h>
 
 #ifdef UE_INLINE_GENERATED_CPP_BY_NAME
 #include UE_INLINE_GENERATED_CPP_BY_NAME(TextToAudioDataAsync)
@@ -33,5 +34,10 @@ void UTextToAudioDataAsync::BroadcastFinalResult()
 
 	Super::BroadcastFinalResult();
 
-	SynthesisCompleted.Broadcast(GetAudioData());
+	AsyncTask(ENamedThreads::GameThread,
+		[this]
+		{
+			SynthesisCompleted.Broadcast(GetAudioData());
+		}
+	);
 }

--- a/Source/AzSpeech/Private/AzSpeech/Tasks/TextToSoundWaveAsync.cpp
+++ b/Source/AzSpeech/Private/AzSpeech/Tasks/TextToSoundWaveAsync.cpp
@@ -26,31 +26,15 @@ UTextToSoundWaveAsync* UTextToSoundWaveAsync::TextToSoundWave(UObject* WorldCont
 
 void UTextToSoundWaveAsync::BroadcastFinalResult()
 {
-	Super::BroadcastFinalResult();
-
 	FScopeLock Lock(&Mutex);
 
-	if (SynthesisCompleted.IsBound())
-	{
-		const TArray<uint8> LastBuffer = GetAudioData();
-		SynthesisCompleted.Broadcast(UAzSpeechHelper::ConvertAudioDataToSoundWave(LastBuffer));
-		SynthesisCompleted.Clear();
-	}
-}
-
-void UTextToSoundWaveAsync::OnSynthesisUpdate(const std::shared_ptr<Microsoft::CognitiveServices::Speech::SpeechSynthesisResult>& LastResult)
-{
-	Super::OnSynthesisUpdate(LastResult);
-
-	if (!UAzSpeechTaskStatus::IsTaskStillValid(this))
+	if (!UAzSpeechTaskStatus::IsTaskActive(this))
 	{
 		return;
 	}
 
-	if (CanBroadcastWithReason(LastResult->Reason))
-	{
-		FScopeLock Lock(&Mutex);
+	Super::BroadcastFinalResult();
 
-		BroadcastFinalResult();
-	}
+	const TArray<uint8> LastBuffer = GetAudioData();
+	SynthesisCompleted.Broadcast(UAzSpeechHelper::ConvertAudioDataToSoundWave(LastBuffer));
 }

--- a/Source/AzSpeech/Private/AzSpeech/Tasks/TextToSoundWaveAsync.cpp
+++ b/Source/AzSpeech/Private/AzSpeech/Tasks/TextToSoundWaveAsync.cpp
@@ -5,6 +5,7 @@
 #include "AzSpeech/Tasks/TextToSoundWaveAsync.h"
 #include "AzSpeech/AzSpeechHelper.h"
 #include <Sound/SoundWave.h>
+#include <Async/Async.h>
 
 #ifdef UE_INLINE_GENERATED_CPP_BY_NAME
 #include UE_INLINE_GENERATED_CPP_BY_NAME(TextToSoundWaveAsync)
@@ -35,6 +36,11 @@ void UTextToSoundWaveAsync::BroadcastFinalResult()
 
 	Super::BroadcastFinalResult();
 
-	const TArray<uint8> LastBuffer = GetAudioData();
-	SynthesisCompleted.Broadcast(UAzSpeechHelper::ConvertAudioDataToSoundWave(LastBuffer));
+	AsyncTask(ENamedThreads::GameThread,
+		[this]
+		{
+			const TArray<uint8> LastBuffer = GetAudioData();
+			SynthesisCompleted.Broadcast(UAzSpeechHelper::ConvertAudioDataToSoundWave(LastBuffer));
+		}
+	);
 }

--- a/Source/AzSpeech/Private/AzSpeech/Tasks/WavFileToTextAsync.cpp
+++ b/Source/AzSpeech/Private/AzSpeech/Tasks/WavFileToTextAsync.cpp
@@ -46,7 +46,7 @@ bool UWavFileToTextAsync::StartAzureTaskWork()
 		return false;
 	}
 	
-	if (HasEmptyParameters(FilePath, FileName, LanguageID))
+	if (AzSpeech::Internal::HasEmptyParam(FilePath, FileName, LanguageID))
 	{
 		return false;
 	}

--- a/Source/AzSpeech/Public/AzSpeech/AzSpeechAnimationData.h
+++ b/Source/AzSpeech/Public/AzSpeech/AzSpeechAnimationData.h
@@ -11,6 +11,8 @@ USTRUCT(BlueprintType, Category = "AzSpeech")
 struct FAzSpeechBlendShapes
 {
 	GENERATED_USTRUCT_BODY()
+
+	FAzSpeechBlendShapes() = default;
 		
 	UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "AzSpeech")
 	TArray<float> Data;
@@ -20,6 +22,8 @@ USTRUCT(BlueprintType, Category = "AzSpeech")
 struct FAzSpeechAnimationData
 {
 	GENERATED_USTRUCT_BODY()
+		
+	FAzSpeechAnimationData() = default;
 
 	UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "AzSpeech")
 	int32 FrameIndex;

--- a/Source/AzSpeech/Public/AzSpeech/AzSpeechAnimationData.h
+++ b/Source/AzSpeech/Public/AzSpeech/AzSpeechAnimationData.h
@@ -1,0 +1,29 @@
+// Author: Lucas Vilas-Boas
+// Year: 2023
+// Repo: https://github.com/lucoiso/UEAzSpeech
+
+#pragma once
+
+#include <CoreMinimal.h>
+#include "AzSpeechAnimationData.generated.h"
+
+USTRUCT(BlueprintType, Category = "AzSpeech")
+struct FAzSpeechBlendShapes
+{
+	GENERATED_USTRUCT_BODY()
+		
+	UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "AzSpeech")
+	TArray<float> Data;
+};
+
+USTRUCT(BlueprintType, Category = "AzSpeech")
+struct FAzSpeechAnimationData
+{
+	GENERATED_USTRUCT_BODY()
+
+	UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "AzSpeech")
+	int32 FrameIndex;
+	
+	UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "AzSpeech")
+	TArray<FAzSpeechBlendShapes> BlendShapes;
+};

--- a/Source/AzSpeech/Public/AzSpeech/AzSpeechHelper.h
+++ b/Source/AzSpeech/Public/AzSpeech/AzSpeechHelper.h
@@ -94,24 +94,67 @@ public:
 	UFUNCTION(BlueprintPure, Category = "AzSpeech")
 	static const bool IsAudioDataValid(const TArray<uint8>& RawData);
 
+	/* Get the available audio input devices in the current platform */
 	UFUNCTION(BlueprintCallable, Category = "AzSpeech")
 	static const TArray<FAzSpeechAudioInputDeviceInfo> GetAvailableAudioInputDevices();
-	
+
+	/* Get the audio input devices info by it's ID */
 	UFUNCTION(BlueprintPure, Category = "AzSpeech")
 	static const FAzSpeechAudioInputDeviceInfo GetAudioInputDeviceInfoFromID(const FString& DeviceID);
 
+	/* Check if the audio input device is currently available */
 	UFUNCTION(BlueprintPure, Category = "AzSpeech")
 	static const bool IsAudioInputDeviceAvailable(const FString& DeviceID);
 
+	/* Check if the device ID is valid */
 	UFUNCTION(BlueprintPure, Category = "AzSpeech", Meta = (DisplayName = "Is Audio Input Device ID Valid"))
 	static const bool IsAudioInputDeviceIDValid(const FString& DeviceID);
 
+	/* Get available modules with content enabled */
 	UFUNCTION(BlueprintPure, Category = "AzSpeech")
 	static const TArray<FString> GetAvailableContentModules();
 
+	/* 
+		Extract the Animation JSON property from Viseme Data.
+
+		JSON Body Format:
+		[
+			FrameIndex: Integer,
+			BlendShapes: [ 
+				[ 
+					Float, 
+					... 
+				], 
+				[ 
+					Float, 
+					... 
+				], 
+				... 
+			]
+		]
+	*/
 	UFUNCTION(BlueprintPure, Category = "AzSpeech")
 	static const FAzSpeechAnimationData ExtractAnimationDataFromVisemeData(const FAzSpeechVisemeData& VisemeData);
+	
+	/*
+		Extract the Animation JSON property from Viseme Data Array.
 
+		JSON Body Format:
+		[
+			FrameIndex: Integer,
+			BlendShapes: [
+				[
+					Float,
+					...
+				],
+				[
+					Float,
+					...
+				],
+				...
+			]
+		]
+	*/
 	UFUNCTION(BlueprintPure, Category = "AzSpeech")
 	static const TArray<FAzSpeechAnimationData> ExtractAnimationDataFromVisemeDataArray(const TArray<FAzSpeechVisemeData>& VisemeData);
 

--- a/Source/AzSpeech/Public/AzSpeech/AzSpeechHelper.h
+++ b/Source/AzSpeech/Public/AzSpeech/AzSpeechHelper.h
@@ -122,11 +122,11 @@ public:
 			FrameIndex: Integer,
 			BlendShapes: [ 
 				[ 
-					Float, 
+					Number, 
 					... 
 				], 
 				[ 
-					Float, 
+					Number, 
 					... 
 				], 
 				... 
@@ -144,11 +144,11 @@ public:
 			FrameIndex: Integer,
 			BlendShapes: [
 				[
-					Float,
+					Number,
 					...
 				],
 				[
-					Float,
+					Number,
 					...
 				],
 				...

--- a/Source/AzSpeech/Public/AzSpeech/AzSpeechHelper.h
+++ b/Source/AzSpeech/Public/AzSpeech/AzSpeechHelper.h
@@ -7,6 +7,8 @@
 #include <CoreMinimal.h>
 #include <Kismet/BlueprintFunctionLibrary.h>
 #include "AzSpeech/AzSpeechAudioInputDeviceInfo.h"
+#include "AzSpeech/AzSpeechAnimationData.h"
+#include "AzSpeech/AzSpeechVisemeData.h"
 #include "AzSpeechHelper.generated.h"
 
 /**
@@ -106,6 +108,12 @@ public:
 
 	UFUNCTION(BlueprintPure, Category = "AzSpeech")
 	static const TArray<FString> GetAvailableContentModules();
+
+	UFUNCTION(BlueprintPure, Category = "AzSpeech")
+	static const FAzSpeechAnimationData ExtractAnimationDataFromVisemeData(const FAzSpeechVisemeData& VisemeData);
+
+	UFUNCTION(BlueprintPure, Category = "AzSpeech")
+	static const TArray<FAzSpeechAnimationData> ExtractAnimationDataFromVisemeDataArray(const TArray<FAzSpeechVisemeData>& VisemeData);
 
 	static const FString GetAzSpeechLogsBaseDir();
 };

--- a/Source/AzSpeech/Public/AzSpeech/AzSpeechVisemeData.h
+++ b/Source/AzSpeech/Public/AzSpeech/AzSpeechVisemeData.h
@@ -1,0 +1,34 @@
+// Author: Lucas Vilas-Boas
+// Year: 2023
+// Repo: https://github.com/lucoiso/UEAzSpeech
+
+#pragma once
+
+#include <CoreMinimal.h>
+#include "AzSpeechVisemeData.generated.h"
+
+USTRUCT(BlueprintType, Category = "AzSpeech")
+struct FAzSpeechVisemeData
+{
+	GENERATED_BODY()
+
+	FAzSpeechVisemeData() = default;
+
+	FAzSpeechVisemeData(const int32 InVisemeID, const int64 InAudioOffsetMilliseconds, const FString& InAnimation) : VisemeID(InVisemeID), AudioOffsetMilliseconds(InAudioOffsetMilliseconds), Animation(InAnimation)
+	{
+	}
+
+	const bool IsValid() const
+	{
+		return VisemeID != -1 && AudioOffsetMilliseconds != -1;
+	}
+
+	UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "AzSpeech")
+	int32 VisemeID = -1;
+
+	UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "AzSpeech")
+	int64 AudioOffsetMilliseconds = -1;
+
+	UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "AzSpeech")
+	FString Animation = FString();
+};

--- a/Source/AzSpeech/Public/AzSpeech/Runnables/AzSpeechRecognitionRunnable.h
+++ b/Source/AzSpeech/Public/AzSpeech/Runnables/AzSpeechRecognitionRunnable.h
@@ -37,9 +37,6 @@ protected:
 
 	class UAzSpeechRecognizerTaskBase* GetOwningRecognizerTask() const;
 
-	virtual void ClearSignals() override;
-	virtual void RemoveBindings() override;
-
 	virtual const bool ApplySDKSettings(const std::shared_ptr<Microsoft::CognitiveServices::Speech::SpeechConfig>& InConfig) const override;
 
 	virtual bool InitializeAzureObject() override;

--- a/Source/AzSpeech/Public/AzSpeech/Runnables/AzSpeechSynthesisRunnable.h
+++ b/Source/AzSpeech/Public/AzSpeech/Runnables/AzSpeechSynthesisRunnable.h
@@ -34,9 +34,6 @@ protected:
 
 	class UAzSpeechSynthesizerTaskBase* GetOwningSynthesizerTask() const;
 
-	virtual void ClearSignals() override;
-	virtual void RemoveBindings() override;
-
 	virtual const bool ApplySDKSettings(const std::shared_ptr<Microsoft::CognitiveServices::Speech::SpeechConfig>& InConfig) const override;
 
 	virtual bool InitializeAzureObject() override;

--- a/Source/AzSpeech/Public/AzSpeech/Runnables/Bases/AzSpeechRunnableBase.h
+++ b/Source/AzSpeech/Public/AzSpeech/Runnables/Bases/AzSpeechRunnableBase.h
@@ -46,27 +46,6 @@ protected:
 	virtual bool InitializeAzureObject();
 	virtual bool CanInitializeTask() const;
 
-	virtual void ClearSignals();
-	virtual void RemoveBindings();
-
-	template<typename SignalTy>
-	void SignalDisconnecter_T(SignalTy& Signal)
-	{
-		if (Signal.IsConnected())
-		{
-			Signal.DisconnectAll();
-		}
-	};
-
-	template<typename DelegateTy>
-	void DelegateDisconnecter_T(DelegateTy& Delegate)
-	{
-		if (Delegate.IsBound())
-		{
-			Delegate.Clear();
-		}
-	};
-
 	std::shared_ptr<Microsoft::CognitiveServices::Speech::SpeechConfig> CreateSpeechConfig() const;
 
 	const std::chrono::seconds GetTaskTimeout() const;
@@ -98,8 +77,10 @@ private:
 	UAzSpeechTaskBase* OwningTask;
 	std::shared_ptr<Microsoft::CognitiveServices::Speech::Audio::AudioConfig> AudioConfig;
 
-#if !UE_BUILD_SHIPPING
 protected:
+	mutable FCriticalSection Mutex;
+
+#if !UE_BUILD_SHIPPING
 	void PrintDebugInformation(const int64 StartTime, const int64 ActivationDelay, const float SleepTime) const;
 #endif
 };

--- a/Source/AzSpeech/Public/AzSpeech/Runnables/Bases/AzSpeechRunnableBase.h
+++ b/Source/AzSpeech/Public/AzSpeech/Runnables/Bases/AzSpeechRunnableBase.h
@@ -98,10 +98,8 @@ private:
 	UAzSpeechTaskBase* OwningTask;
 	std::shared_ptr<Microsoft::CognitiveServices::Speech::Audio::AudioConfig> AudioConfig;
 
-protected:
-	mutable FCriticalSection Mutex;
-
 #if !UE_BUILD_SHIPPING
+protected:
 	void PrintDebugInformation(const int64 StartTime, const int64 ActivationDelay, const float SleepTime) const;
 #endif
 };

--- a/Source/AzSpeech/Public/AzSpeech/Tasks/Bases/AzSpeechSpeechSynthesisBase.h
+++ b/Source/AzSpeech/Public/AzSpeech/Tasks/Bases/AzSpeechSpeechSynthesisBase.h
@@ -28,8 +28,8 @@ public:
 	virtual void SetReadyToDestroy() override;
 
 protected:
-	virtual void BroadcastFinalResult() override;
 	virtual void OnSynthesisUpdate(const std::shared_ptr<Microsoft::CognitiveServices::Speech::SpeechSynthesisResult>& LastResult) override;
+	virtual void BroadcastFinalResult() override;
 
 	UFUNCTION()
 	void OnAudioPlayStateChanged(const EAudioComponentPlayState PlayState);

--- a/Source/AzSpeech/Public/AzSpeech/Tasks/Bases/AzSpeechSpeechSynthesisBase.h
+++ b/Source/AzSpeech/Public/AzSpeech/Tasks/Bases/AzSpeechSpeechSynthesisBase.h
@@ -28,7 +28,6 @@ public:
 	virtual void SetReadyToDestroy() override;
 
 protected:
-	virtual void OnSynthesisUpdate(const std::shared_ptr<Microsoft::CognitiveServices::Speech::SpeechSynthesisResult>& LastResult) override;
 	virtual void BroadcastFinalResult() override;
 
 	UFUNCTION()

--- a/Source/AzSpeech/Public/AzSpeech/Tasks/Bases/AzSpeechSynthesizerTaskBase.h
+++ b/Source/AzSpeech/Public/AzSpeech/Tasks/Bases/AzSpeechSynthesizerTaskBase.h
@@ -76,7 +76,7 @@ public:
 	FVisemeReceived VisemeReceived;
 
 	UFUNCTION(BlueprintPure, Category = "AzSpeech", Meta = (DisplayName = "Get Last Viseme Data"))
-	const FAzSpeechVisemeData GetVisemeData() const;
+	const FAzSpeechVisemeData& GetLastVisemeData() const;
 
 	UFUNCTION(BlueprintPure, Category = "AzSpeech")
 	const TArray<FAzSpeechVisemeData> GetVisemeDataArray() const;

--- a/Source/AzSpeech/Public/AzSpeech/Tasks/Bases/AzSpeechSynthesizerTaskBase.h
+++ b/Source/AzSpeech/Public/AzSpeech/Tasks/Bases/AzSpeechSynthesizerTaskBase.h
@@ -76,7 +76,7 @@ public:
 	FVisemeReceived VisemeReceived;
 
 	UFUNCTION(BlueprintPure, Category = "AzSpeech", Meta = (DisplayName = "Get Last Viseme Data"))
-	const FAzSpeechVisemeData& GetLastVisemeData() const;
+	const FAzSpeechVisemeData GetLastVisemeData() const;
 
 	UFUNCTION(BlueprintPure, Category = "AzSpeech")
 	const TArray<FAzSpeechVisemeData> GetVisemeDataArray() const;

--- a/Source/AzSpeech/Public/AzSpeech/Tasks/Bases/AzSpeechSynthesizerTaskBase.h
+++ b/Source/AzSpeech/Public/AzSpeech/Tasks/Bases/AzSpeechSynthesizerTaskBase.h
@@ -75,7 +75,7 @@ public:
 	UPROPERTY(BlueprintAssignable, Category = "AzSpeech")
 	FVisemeReceived VisemeReceived;
 
-	UFUNCTION(BlueprintPure, Category = "AzSpeech")
+	UFUNCTION(BlueprintPure, Category = "AzSpeech", Meta = (DisplayName = "Get Last Viseme Data"))
 	const FAzSpeechVisemeData GetVisemeData() const;
 
 	UFUNCTION(BlueprintPure, Category = "AzSpeech")

--- a/Source/AzSpeech/Public/AzSpeech/Tasks/Bases/AzSpeechSynthesizerTaskBase.h
+++ b/Source/AzSpeech/Public/AzSpeech/Tasks/Bases/AzSpeechSynthesizerTaskBase.h
@@ -6,38 +6,13 @@
 
 #include <CoreMinimal.h>
 #include "AzSpeech/Tasks/Bases/AzSpeechTaskBase.h"
+#include "AzSpeech/AzSpeechVisemeData.h"
 
 THIRD_PARTY_INCLUDES_START
 #include <speechapi_cxx_speech_synthesis_result.h>
 THIRD_PARTY_INCLUDES_END
 
 #include "AzSpeechSynthesizerTaskBase.generated.h"
-
-USTRUCT(BlueprintType, Category = "AzSpeech")
-struct FAzSpeechVisemeData
-{
-	GENERATED_BODY()
-
-	FAzSpeechVisemeData() = default;
-
-	FAzSpeechVisemeData(const int32 InVisemeID, const int64 InAudioOffsetMilliseconds, const FString& InAnimation) : VisemeID(InVisemeID), AudioOffsetMilliseconds(InAudioOffsetMilliseconds), Animation(InAnimation)
-	{
-	}
-
-	const bool IsValid() const
-	{
-		return VisemeID != -1 && AudioOffsetMilliseconds != -1;
-	}
-
-	UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "AzSpeech")
-	int32 VisemeID = -1;
-
-	UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "AzSpeech")
-	int64 AudioOffsetMilliseconds = -1;
-
-	UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "AzSpeech")
-	FString Animation = FString();
-};
 
 class USoundWave;
 

--- a/Source/AzSpeech/Public/AzSpeech/Tasks/Bases/AzSpeechSynthesizerTaskBase.h
+++ b/Source/AzSpeech/Public/AzSpeech/Tasks/Bases/AzSpeechSynthesizerTaskBase.h
@@ -102,8 +102,6 @@ protected:
 	
 	void StartSynthesisWork(const std::shared_ptr<Microsoft::CognitiveServices::Speech::Audio::AudioConfig>& InAudioConfig);
 	
-	const bool CanBroadcastWithReason(const Microsoft::CognitiveServices::Speech::ResultReason& Reason) const;
-	
 	virtual void OnVisemeReceived(const FAzSpeechVisemeData& VisemeData);
 	virtual void OnSynthesisUpdate(const std::shared_ptr<Microsoft::CognitiveServices::Speech::SpeechSynthesisResult>& LastResult);
 	
@@ -113,5 +111,4 @@ private:
 	bool bLastResultIsValid = false;
 
 	void ValidateVoiceName();
-	void LogSynthesisResultStatus(const bool bSuccess) const;
 };

--- a/Source/AzSpeech/Public/AzSpeech/Tasks/Bases/AzSpeechTaskBase.h
+++ b/Source/AzSpeech/Public/AzSpeech/Tasks/Bases/AzSpeechTaskBase.h
@@ -65,18 +65,6 @@ protected:
 	bool bEndingPIE = false;
 #endif
 
-	template<typename ...Args>
-	constexpr const bool HasEmptyParameters(Args&& ...args) const
-	{
-		const bool bOutput = AzSpeech::Internal::HasEmptyParam(std::forward<Args>(args)...);
-		if (bOutput)
-		{
-			UE_LOG(LogAzSpeech_Internal, Error, TEXT("Task: %s (%d); Function: %s; Message: Missing parameters"), *TaskName.ToString(), GetUniqueID(), *FString(__func__));
-		}
-
-		return bOutput;
-	}
-
 private:
 	bool bIsTaskActive = false;
 	bool bIsReadyToDestroy = false;

--- a/Source/AzSpeech/Public/AzSpeech/Tasks/Bases/AzSpeechWavFileSynthesisBase.h
+++ b/Source/AzSpeech/Public/AzSpeech/Tasks/Bases/AzSpeechWavFileSynthesisBase.h
@@ -21,13 +21,11 @@ public:
 	UPROPERTY(BlueprintAssignable, Category = "AzSpeech")
 	FBooleanSynthesisDelegate SynthesisCompleted;
 	
-	virtual void Activate() override;
-	
+	virtual void Activate() override;	
 	virtual void SetReadyToDestroy() override;
 
 protected:
 	virtual bool StartAzureTaskWork() override;
-	virtual void OnSynthesisUpdate(const std::shared_ptr<Microsoft::CognitiveServices::Speech::SpeechSynthesisResult>& LastResult) override;
 	virtual void BroadcastFinalResult() override;
 
 	FString FilePath;

--- a/Source/AzSpeech/Public/AzSpeech/Tasks/SSMLToAudioDataAsync.h
+++ b/Source/AzSpeech/Public/AzSpeech/Tasks/SSMLToAudioDataAsync.h
@@ -26,6 +26,5 @@ public:
 	static USSMLToAudioDataAsync* SSMLToAudioData(UObject* WorldContextObject, const FString& SynthesisSSML);
 	
 protected:
-	virtual void OnSynthesisUpdate(const std::shared_ptr<Microsoft::CognitiveServices::Speech::SpeechSynthesisResult>& LastResult) override;
 	virtual void BroadcastFinalResult() override;
 };

--- a/Source/AzSpeech/Public/AzSpeech/Tasks/SSMLToSoundWaveAsync.h
+++ b/Source/AzSpeech/Public/AzSpeech/Tasks/SSMLToSoundWaveAsync.h
@@ -26,6 +26,5 @@ public:
 	static USSMLToSoundWaveAsync* SSMLToSoundWave(UObject* WorldContextObject, const FString& SynthesisSSML);
 
 protected:
-	virtual void OnSynthesisUpdate(const std::shared_ptr<Microsoft::CognitiveServices::Speech::SpeechSynthesisResult>& LastResult) override;
 	virtual void BroadcastFinalResult() override;
 };

--- a/Source/AzSpeech/Public/AzSpeech/Tasks/TextToAudioDataAsync.h
+++ b/Source/AzSpeech/Public/AzSpeech/Tasks/TextToAudioDataAsync.h
@@ -26,6 +26,5 @@ public:
 	static UTextToAudioDataAsync* TextToAudioData(UObject* WorldContextObject, const FString& SynthesisText, const FString& VoiceName = "Default", const FString& LanguageID = "Default");
 
 protected:
-	virtual void OnSynthesisUpdate(const std::shared_ptr<Microsoft::CognitiveServices::Speech::SpeechSynthesisResult>& LastResult) override;
 	virtual void BroadcastFinalResult() override;
 };

--- a/Source/AzSpeech/Public/AzSpeech/Tasks/TextToSoundWaveAsync.h
+++ b/Source/AzSpeech/Public/AzSpeech/Tasks/TextToSoundWaveAsync.h
@@ -26,6 +26,5 @@ public:
 	static UTextToSoundWaveAsync* TextToSoundWave(UObject* WorldContextObject, const FString& SynthesisText, const FString& VoiceName = "Default", const FString& LanguageID = "Default");
 
 protected:
-	virtual void OnSynthesisUpdate(const std::shared_ptr<Microsoft::CognitiveServices::Speech::SpeechSynthesisResult>& LastResult) override;
 	virtual void BroadcastFinalResult() override;
 };

--- a/Source/AzSpeechEditor/Private/SAzSpeechAudioGenerator.cpp
+++ b/Source/AzSpeechEditor/Private/SAzSpeechAudioGenerator.cpp
@@ -133,10 +133,12 @@ void SAzSpeechAudioGenerator::Construct([[maybe_unused]] const FArguments&)
 				.AutoHeight()
 				[
 					ContentPairCreator_Lambda(CenterTextCreator_Lambda("Synthesis Text/SSML"), SNew(SMultiLineEditableTextBox)
-					.OnTextChanged_Lambda([this](const FText& InText)
-					{
-						SynthesisText = InText;
-					}))
+					.OnTextChanged_Lambda(
+						[this](const FText& InText)
+						{
+							SynthesisText = InText;
+						}
+					))
 				]
 				+ SVerticalBox::Slot()
 				.Padding(Slot_Padding)
@@ -144,37 +146,41 @@ void SAzSpeechAudioGenerator::Construct([[maybe_unused]] const FArguments&)
 				[
 					ContentPairCreator_Lambda(CenterTextCreator_Lambda("SSML"), SNew(SCheckBox)
 					.IsChecked(ECheckBoxState::Unchecked)
-					.OnCheckStateChanged_Lambda([this](const ECheckBoxState InState)
-					{
-						bIsSSMLBased = InState == ECheckBoxState::Checked;
-					}))
+					.OnCheckStateChanged_Lambda(
+						[this](const ECheckBoxState InState)
+						{
+							bIsSSMLBased = InState == ECheckBoxState::Checked;
+						}
+					))
 				]
 				+ SVerticalBox::Slot()
 				.Padding(Slot_Padding)
 				.AutoHeight()
 				[
 					ContentPairCreator_Lambda(CenterTextCreator_Lambda("Locale"), SNew(SEditableTextBox)
-					.OnTextCommitted_Lambda([this](const FText& InText, [[maybe_unused]] ETextCommit::Type InCommitType)
-					{
-						const FString NewValue = FText::TrimPrecedingAndTrailing(InText).ToString();
-
-						if (Locale.Equals(NewValue, ESearchCase::IgnoreCase))
+					.OnTextCommitted_Lambda(
+						[this](const FText& InText, [[maybe_unused]] ETextCommit::Type InCommitType)
 						{
-							return;
-						}
+							const FString NewValue = FText::TrimPrecedingAndTrailing(InText).ToString();
 
-						Locale = NewValue;
-						VoiceComboBox->SetSelectedItem(SelectVoice);
+							if (Locale.Equals(NewValue, ESearchCase::IgnoreCase))
+							{
+								return;
+							}
 
-						if (Locale.Equals("Auto", ESearchCase::IgnoreCase))
-						{
-							AvailableVoices = { SelectVoice };
+							Locale = NewValue;
+							VoiceComboBox->SetSelectedItem(SelectVoice);
+
+							if (Locale.Equals("Auto", ESearchCase::IgnoreCase))
+							{
+								AvailableVoices = { SelectVoice };
+							}
+							else if (!Locale.IsEmpty())
+							{
+								UpdateAvailableVoices();
+							}
 						}
-						else if (!Locale.IsEmpty())
-						{
-							UpdateAvailableVoices();
-						}
-					}))
+					))
 				]
 				+ SVerticalBox::Slot()
 				.Padding(Slot_Padding)
@@ -183,10 +189,12 @@ void SAzSpeechAudioGenerator::Construct([[maybe_unused]] const FArguments&)
 					ContentPairCreator_Lambda(CenterTextCreator_Lambda("Voice"), SAssignNew(VoiceComboBox, STextComboBox)
 					.OptionsSource(&AvailableVoices)
 					.InitiallySelectedItem(SelectVoice)
-					.OnSelectionChanged_Lambda([this](const TSharedPtr<FString>& InStr, [[maybe_unused]] ESelectInfo::Type)
-					{
-						Voice = InStr->TrimStartAndEnd();
-					}))
+					.OnSelectionChanged_Lambda(
+						[this](const TSharedPtr<FString>& InStr, [[maybe_unused]] ESelectInfo::Type)
+						{
+							Voice = InStr->TrimStartAndEnd();
+						}
+					))
 				]
 				+ SVerticalBox::Slot()
 				.Padding(Slot_Padding)
@@ -195,30 +203,36 @@ void SAzSpeechAudioGenerator::Construct([[maybe_unused]] const FArguments&)
 					ContentPairCreator_Lambda(CenterTextCreator_Lambda("Module"), SNew(STextComboBox)
 					.OptionsSource(&AvailableModules)
 					.InitiallySelectedItem(GameModule)
-					.OnSelectionChanged_Lambda([this](const TSharedPtr<FString>& InStr, [[maybe_unused]] ESelectInfo::Type)
-					{
-						Module = InStr->TrimStartAndEnd();
-					}))
+					.OnSelectionChanged_Lambda(
+						[this](const TSharedPtr<FString>& InStr, [[maybe_unused]] ESelectInfo::Type)
+						{
+							Module = InStr->TrimStartAndEnd();
+						}
+					))
 				]
 				+ SVerticalBox::Slot()
 				.Padding(Slot_Padding)
 				.AutoHeight()
 				[
 					ContentPairCreator_Lambda(CenterTextCreator_Lambda("Relative Path"), SAssignNew(PathInput, SEditableTextBox)
-					.OnTextCommitted_Lambda([this](const FText& InText, [[maybe_unused]] ETextCommit::Type InCommitType)
-					{
-						OnFileInfoCommited(InText, RelativePath, PathInput);
-					}))
+					.OnTextCommitted_Lambda(
+						[this](const FText& InText, [[maybe_unused]] ETextCommit::Type InCommitType)
+						{
+							OnFileInfoCommited(InText, RelativePath, PathInput);
+						}
+					))
 				]
 				+ SVerticalBox::Slot()
 				.Padding(Slot_Padding)
 				.AutoHeight()
 				[
 					ContentPairCreator_Lambda(CenterTextCreator_Lambda("Asset Name"), SAssignNew(AssetNameInput, SEditableTextBox)
-					.OnTextCommitted_Lambda([this](const FText& InText, [[maybe_unused]] ETextCommit::Type InCommitType)
-					{
-						OnFileInfoCommited(InText, AssetName, AssetNameInput);
-					}))
+					.OnTextCommitted_Lambda(
+						[this](const FText& InText, [[maybe_unused]] ETextCommit::Type InCommitType)
+						{
+							OnFileInfoCommited(InText, AssetName, AssetNameInput);
+						}
+					))
 				]
 				+ SVerticalBox::Slot()
 				.Padding(Margin_Spacing)


### PR DESCRIPTION
## Changes
* Set audio compression to not occur in transient sound waves
* Fix audio compression occurring more than one time
* Fix audio compression being called outside audio thread
* Separate tasks signals to avoid the completion delegate sending wrong data
* Set to only broadcasts occurs in game thread
* Set the runnable threads to try lock on exit to avoid crashes after End PIE
* Add comments functions
* Move Viseme Data to a separate header
* Create new structure: Animation Data
* Added new functions to extract Animation JSON Data from Viseme Data

![image](https://user-images.githubusercontent.com/77353979/225355753-80b06243-beeb-4ca1-8bfb-eaebdccf386f.png)
