### PR TITLE
v1.6.4

### DIFF
--- a/AzSpeech.uplugin
+++ b/AzSpeech.uplugin
@@ -1,7 +1,7 @@
 {
 	"FileVersion": 3,
-	"Version": 20,
-	"VersionName": "1.6.3",
+	"Version": 21,
+	"VersionName": "1.6.4",
 	"FriendlyName": "AzSpeech - Voice and Text",
 	"Description": "Integrates Azure Speech Cognitive Services into the Engine by adding functions to perform recognition and synthesis via asynchronous tasks.",
 	"Category": "Game Features",

--- a/Config/DefaultAzSpeech.ini
+++ b/Config/DefaultAzSpeech.ini
@@ -161,3 +161,10 @@
 ; Properties
 +PropertyRedirects=(OldName="AzSpeechHelper.ConvertWavFileToSoundWave.OutputModulePath", NewName="AzSpeechHelper.ConvertWavFileToSoundWave.OutputModule")
 +PropertyRedirects=(OldName="AzSpeechHelper.ConvertAudioDataToSoundWave.OutputModulePath", NewName="AzSpeechHelper.ConvertAudioDataToSoundWave.OutputModule")
+
+; v1.6.4
+; Properties
++PropertyRedirects=(OldName="AzSpeechSettingsOptions.SubscriptionKey", NewName="AzSpeechSettingsOptions.SubscriptionOptions.SubscriptionKey")
++PropertyRedirects=(OldName="AzSpeechSettingsOptions.RegionID", NewName="AzSpeechSettingsOptions.SubscriptionOptions.RegionID")
++PropertyRedirects=(OldName="AzSpeechSettingsOptions.bUsePrivateEndpoint", NewName="AzSpeechSettingsOptions.SubscriptionOptions.bUsePrivateEndpoint")
++PropertyRedirects=(OldName="AzSpeechSettingsOptions.PrivateEndpoint", NewName="AzSpeechSettingsOptions.SubscriptionOptions.PrivateEndpoint")

--- a/Source/AzSpeech/Private/AzSpeech/Structures/AzSpeechSettingsOptions.cpp
+++ b/Source/AzSpeech/Private/AzSpeech/Structures/AzSpeechSettingsOptions.cpp
@@ -4,55 +4,164 @@
 
 #include "AzSpeech/Structures/AzSpeechSettingsOptions.h"
 #include "AzSpeech/AzSpeechSettings.h"
+#include "AzSpeechInternalFuncs.h"
 
 #ifdef UE_INLINE_GENERATED_CPP_BY_NAME
 #include UE_INLINE_GENERATED_CPP_BY_NAME(AzSpeechSettingsOptions)
 #endif
+
+bool IsAutoLanguage(const FName& Value)
+{
+	return Value.IsEqual("Auto", ENameCase::IgnoreCase);
+}
+
+bool IsDefault(const FName& Value)
+{
+	return Value.IsEqual("Default", ENameCase::IgnoreCase) || AzSpeech::Internal::HasEmptyParam(Value);
+}
 
 FAzSpeechSettingsOptions::FAzSpeechSettingsOptions()
 {
 	SetDefaults();
 }
 
-FAzSpeechSettingsOptions::FAzSpeechSettingsOptions(const FName& LanguageID)
-{
-	SetDefaults();
-
-	this->LanguageID = LanguageID;
-}
-
-FAzSpeechSettingsOptions::FAzSpeechSettingsOptions(const FName& LanguageID, const FName& VoiceName)
-{
-	SetDefaults();
-
-	this->LanguageID = LanguageID;
-	this->VoiceName = VoiceName;
-}
-
 void FAzSpeechSettingsOptions::SetDefaults()
+{
+	SubscriptionOptions.SetDefaults();
+	RecognitionOptions.SetDefaults();
+	SynthesisOptions.SetDefaults();
+}
+
+FAzSpeechSubscriptionOptions::FAzSpeechSubscriptionOptions()
+{
+	SetDefaults();
+}
+
+void FAzSpeechSubscriptionOptions::SyncEndpointWithRegion()
+{
+	if (!bUsePrivateEndpoint)
+	{
+		PrivateEndpoint = *FString::Format(TEXT("https://{0}.api.cognitive.microsoft.com/sts/v1.0/issuetoken"), { RegionID.ToString() });
+	}
+}
+
+void FAzSpeechSubscriptionOptions::SetDefaults()
 {
 	if (const UAzSpeechSettings* const Settings = GetDefault<UAzSpeechSettings>())
 	{
-		SubscriptionKey = Settings->DefaultOptions.SubscriptionKey;
-		RegionID = Settings->DefaultOptions.RegionID;
-		bUsePrivateEndpoint = Settings->DefaultOptions.bUsePrivateEndpoint;
-		PrivateEndpoint = Settings->DefaultOptions.PrivateEndpoint;
-		LanguageID = Settings->DefaultOptions.LanguageID;
-		AutoCandidateLanguages = Settings->DefaultOptions.AutoCandidateLanguages;
-		VoiceName = Settings->DefaultOptions.VoiceName;
-		ProfanityFilter = Settings->DefaultOptions.ProfanityFilter;
-		bEnableViseme = Settings->DefaultOptions.bEnableViseme;
-		SpeechSynthesisOutputFormat = Settings->DefaultOptions.SpeechSynthesisOutputFormat;
-		SpeechRecognitionOutputFormat = Settings->DefaultOptions.SpeechRecognitionOutputFormat;
+		SubscriptionKey = Settings->DefaultOptions.SubscriptionOptions.SubscriptionKey;
+		RegionID = Settings->DefaultOptions.SubscriptionOptions.RegionID;
+		bUsePrivateEndpoint = Settings->DefaultOptions.SubscriptionOptions.bUsePrivateEndpoint;
+		PrivateEndpoint = Settings->DefaultOptions.SubscriptionOptions.PrivateEndpoint;
 	}
 
 	SyncEndpointWithRegion();
 }
 
-void FAzSpeechSettingsOptions::SyncEndpointWithRegion()
+FAzSpeechRecognitionOptions::FAzSpeechRecognitionOptions()
 {
-	if (!bUsePrivateEndpoint)
+	SetDefaults();
+}
+
+FAzSpeechRecognitionOptions::FAzSpeechRecognitionOptions(const FName& LanguageID)
+{
+	SetDefaults();
+
+	if (IsAutoLanguage(LanguageID))
 	{
-		PrivateEndpoint = *FString::Format(TEXT("https://{0}.api.cognitive.microsoft.com/sts/v1.0/issuetoken"), { RegionID.ToString() });
+		this->bUseLanguageIdentification = true;
+		this->LanguageID = LanguageID;
+	}
+	else if (IsDefault(LanguageID))
+	{
+		this->LanguageID = GetDefault<UAzSpeechSettings>()->DefaultOptions.RecognitionOptions.LanguageID;
+	}
+
+	this->LanguageID = LanguageID;
+}
+
+uint8 FAzSpeechRecognitionOptions::GetMaxAllowedCandidateLanguages() const
+{
+	switch (LanguageIdentificationMode)
+	{
+		case EAzSpeechLanguageIdentificationMode::AtStart:
+			return 4u;
+
+		case EAzSpeechLanguageIdentificationMode::Continuous:
+			return 10u;
+
+		default:
+			break;
+	}
+
+	return 4u;
+}
+
+void FAzSpeechRecognitionOptions::SetDefaults()
+{
+	if (const UAzSpeechSettings* const Settings = GetDefault<UAzSpeechSettings>())
+	{
+		LanguageID = Settings->DefaultOptions.RecognitionOptions.LanguageID;
+		CandidateLanguages = Settings->DefaultOptions.RecognitionOptions.CandidateLanguages;
+		SpeechRecognitionOutputFormat = Settings->DefaultOptions.RecognitionOptions.SpeechRecognitionOutputFormat;
+		bUseLanguageIdentification = Settings->DefaultOptions.RecognitionOptions.bUseLanguageIdentification;
+		ProfanityFilter = Settings->DefaultOptions.RecognitionOptions.ProfanityFilter;
+		LanguageIdentificationMode = Settings->DefaultOptions.RecognitionOptions.LanguageIdentificationMode;
+		SegmentationSilenceTimeoutMs = Settings->DefaultOptions.RecognitionOptions.SegmentationSilenceTimeoutMs;
+		InitialSilenceTimeoutMs = Settings->DefaultOptions.RecognitionOptions.InitialSilenceTimeoutMs;
+	}
+}
+
+FAzSpeechSynthesisOptions::FAzSpeechSynthesisOptions()
+{
+	SetDefaults();
+}
+
+FAzSpeechSynthesisOptions::FAzSpeechSynthesisOptions(const FName& LanguageID)
+{
+	SetDefaults();
+
+	if (IsAutoLanguage(LanguageID))
+	{
+		this->bUseLanguageIdentification = true;
+		this->LanguageID = LanguageID;
+	}
+	else if (IsDefault(LanguageID))
+	{
+		this->LanguageID = GetDefault<UAzSpeechSettings>()->DefaultOptions.SynthesisOptions.LanguageID;
+	}
+
+	this->LanguageID = LanguageID;
+}
+
+FAzSpeechSynthesisOptions::FAzSpeechSynthesisOptions(const FName& LanguageID, const FName& VoiceName)
+{
+	SetDefaults();
+
+	if (IsAutoLanguage(LanguageID))
+	{
+		this->bUseLanguageIdentification = true;
+		this->LanguageID = LanguageID;
+	}
+	else if (IsDefault(LanguageID))
+	{
+		this->LanguageID = GetDefault<UAzSpeechSettings>()->DefaultOptions.SynthesisOptions.LanguageID;
+	}
+
+	this->LanguageID = LanguageID;
+	this->VoiceName = IsDefault(VoiceName) ? GetDefault<UAzSpeechSettings>()->DefaultOptions.SynthesisOptions.VoiceName : VoiceName;
+}
+
+void FAzSpeechSynthesisOptions::SetDefaults()
+{
+	if (const UAzSpeechSettings* const Settings = GetDefault<UAzSpeechSettings>())
+	{
+		LanguageID = Settings->DefaultOptions.SynthesisOptions.LanguageID;
+		VoiceName = Settings->DefaultOptions.SynthesisOptions.VoiceName;
+		bEnableViseme = Settings->DefaultOptions.SynthesisOptions.bEnableViseme;
+		SpeechSynthesisOutputFormat = Settings->DefaultOptions.SynthesisOptions.SpeechSynthesisOutputFormat;
+		bUseLanguageIdentification = Settings->DefaultOptions.SynthesisOptions.bUseLanguageIdentification;
+		ProfanityFilter = Settings->DefaultOptions.SynthesisOptions.ProfanityFilter;
+		LanguageIdentificationMode = Settings->DefaultOptions.SynthesisOptions.LanguageIdentificationMode;
 	}
 }

--- a/Source/AzSpeech/Private/AzSpeech/Tasks/Bases/AzSpeechAudioDataSynthesisBase.cpp
+++ b/Source/AzSpeech/Private/AzSpeech/Tasks/Bases/AzSpeechAudioDataSynthesisBase.cpp
@@ -3,6 +3,7 @@
 // Repo: https://github.com/lucoiso/UEAzSpeech
 
 #include "AzSpeech/Tasks/Bases/AzSpeechAudioDataSynthesisBase.h"
+#include "AzSpeechInternalFuncs.h"
 
 #ifdef UE_INLINE_GENERATED_CPP_BY_NAME
 #include UE_INLINE_GENERATED_CPP_BY_NAME(AzSpeechAudioDataSynthesisBase)

--- a/Source/AzSpeech/Private/AzSpeech/Tasks/Bases/AzSpeechRecognizerTaskBase.cpp
+++ b/Source/AzSpeech/Private/AzSpeech/Tasks/Bases/AzSpeechRecognizerTaskBase.cpp
@@ -4,6 +4,7 @@
 
 #include "AzSpeech/Tasks/Bases/AzSpeechRecognizerTaskBase.h"
 #include "AzSpeech/Runnables/AzSpeechRecognitionRunnable.h"
+#include "AzSpeech/AzSpeechSettings.h"
 #include "LogAzSpeech.h"
 #include <Async/Async.h>
 
@@ -14,6 +15,11 @@
 #ifdef UE_INLINE_GENERATED_CPP_BY_NAME
 #include UE_INLINE_GENERATED_CPP_BY_NAME(AzSpeechRecognizerTaskBase)
 #endif
+
+const FAzSpeechRecognitionOptions UAzSpeechRecognizerTaskBase::GetRecognitionOptions() const
+{
+	return RecognitionOptions;
+}
 
 const FString UAzSpeechRecognizerTaskBase::GetRecognizedString() const
 {

--- a/Source/AzSpeech/Private/AzSpeech/Tasks/Bases/AzSpeechSynthesizerTaskBase.cpp
+++ b/Source/AzSpeech/Private/AzSpeech/Tasks/Bases/AzSpeechSynthesizerTaskBase.cpp
@@ -4,6 +4,7 @@
 
 #include "AzSpeech/Tasks/Bases/AzSpeechSynthesizerTaskBase.h"
 #include "AzSpeech/Runnables/AzSpeechSynthesisRunnable.h"
+#include "AzSpeech/AzSpeechSettings.h"
 #include "AzSpeech/AzSpeechHelper.h"
 #include "AzSpeechInternalFuncs.h"
 #include "LogAzSpeech.h"
@@ -75,6 +76,11 @@ const bool UAzSpeechSynthesizerTaskBase::IsLastResultValid() const
 const FString UAzSpeechSynthesizerTaskBase::GetSynthesisText() const
 {
 	return SynthesisText;
+}
+
+const FAzSpeechSynthesisOptions UAzSpeechSynthesizerTaskBase::GetSynthesisOptions() const
+{
+	return SynthesisOptions;
 }
 
 const bool UAzSpeechSynthesizerTaskBase::IsSSMLBased() const

--- a/Source/AzSpeech/Private/AzSpeech/Tasks/Bases/AzSpeechTaskBase.cpp
+++ b/Source/AzSpeech/Private/AzSpeech/Tasks/Bases/AzSpeechTaskBase.cpp
@@ -33,6 +33,8 @@ void UAzSpeechTaskBase::Activate()
 
 	TaskName = *NewTaskName;
 
+	SubscriptionOptions.SyncEndpointWithRegion();
+
 	UE_LOG(LogAzSpeech, Display, TEXT("Task: %s (%d); Function: %s; Message: Activating task"), *TaskName.ToString(), GetUniqueID(), *FString(__func__));
 
 	bIsTaskActive = true;
@@ -72,19 +74,14 @@ void UAzSpeechTaskBase::StopAzSpeechTask()
 	SetReadyToDestroy();
 }
 
-const bool UAzSpeechTaskBase::IsUsingAutoLanguage() const
-{
-	return GetTaskOptions().LanguageID.ToString().Equals("Auto", ESearchCase::IgnoreCase);
-}
-
 const FName UAzSpeechTaskBase::GetTaskName() const
 {
 	return TaskName;
 }
 
-const FAzSpeechSettingsOptions UAzSpeechTaskBase::GetTaskOptions() const
+const FAzSpeechSubscriptionOptions UAzSpeechTaskBase::GetSubscriptionOptions() const
 {
-	return TaskOptions;
+	return SubscriptionOptions;
 }
 
 void UAzSpeechTaskBase::SetReadyToDestroy()
@@ -151,40 +148,6 @@ void UAzSpeechTaskBase::PrePIEEnded(bool bIsSimulating)
 	StopAzSpeechTask();
 }
 #endif
-
-FAzSpeechSettingsOptions UAzSpeechTaskBase::GetValidatedOptions(const FAzSpeechSettingsOptions& Options)
-{
-	FAzSpeechSettingsOptions Output = Options;
-	Output.LanguageID = GetValidatedLanguageID(Options.LanguageID);
-	Output.VoiceName = GetValidatedVoiceName(Options.VoiceName);
-
-	if (Output.bUsePrivateEndpoint && AzSpeech::Internal::HasEmptyParam(Output.PrivateEndpoint) && !AzSpeech::Internal::HasEmptyParam(Output.RegionID))
-	{
-		Output.bUsePrivateEndpoint = false;
-	}
-
-	return Output;
-}
-
-FName UAzSpeechTaskBase::GetValidatedLanguageID(const FName& Language)
-{
-	if (AzSpeech::Internal::HasEmptyParam(Language) || Language.ToString().Equals("Default", ESearchCase::IgnoreCase))
-	{
-		return UAzSpeechSettings::Get()->DefaultOptions.LanguageID;
-	}
-
-	return Language;
-}
-
-FName UAzSpeechTaskBase::GetValidatedVoiceName(const FName& Voice)
-{
-	if (AzSpeech::Internal::HasEmptyParam(Voice) || Voice.ToString().Equals("Default", ESearchCase::IgnoreCase))
-	{
-		return UAzSpeechSettings::Get()->DefaultOptions.VoiceName;
-	}
-
-	return Voice;
-}
 
 bool UAzSpeechTaskStatus::IsTaskActive(const UAzSpeechTaskBase* Test)
 {

--- a/Source/AzSpeech/Private/AzSpeech/Tasks/Bases/AzSpeechWavFileSynthesisBase.cpp
+++ b/Source/AzSpeech/Private/AzSpeech/Tasks/Bases/AzSpeechWavFileSynthesisBase.cpp
@@ -4,6 +4,7 @@
 
 #include "AzSpeech/Tasks/Bases/AzSpeechWavFileSynthesisBase.h"
 #include "AzSpeech/AzSpeechHelper.h"
+#include "AzSpeechInternalFuncs.h"
 #include "LogAzSpeech.h"
 #include <HAL/FileManager.h>
 
@@ -77,7 +78,7 @@ bool UAzSpeechWavFileSynthesisBase::StartAzureTaskWork()
 		return false;
 	}
 
-	if (AzSpeech::Internal::HasEmptyParam(SynthesisText, FilePath, FileName) || (!bIsSSMLBased && AzSpeech::Internal::HasEmptyParam(GetTaskOptions().VoiceName, GetTaskOptions().LanguageID)))
+	if (AzSpeech::Internal::HasEmptyParam(SynthesisText, FilePath, FileName) || (!bIsSSMLBased && AzSpeech::Internal::HasEmptyParam(GetSynthesisOptions().VoiceName, GetSynthesisOptions().LanguageID)))
 	{
 		return false;
 	}

--- a/Source/AzSpeech/Private/AzSpeech/Tasks/GetAvailableVoicesAsync.cpp
+++ b/Source/AzSpeech/Private/AzSpeech/Tasks/GetAvailableVoicesAsync.cpp
@@ -93,16 +93,16 @@ const TArray<FString> UGetAvailableVoicesAsync::GetAvailableVoices() const
 
 	std::shared_ptr<Microsoft::CognitiveServices::Speech::SpeechConfig> SpeechConfig;
 	const UAzSpeechSettings* const Settings = UAzSpeechSettings::Get();
-	const std::string SubscriptionKey = TCHAR_TO_UTF8(*Settings->DefaultOptions.SubscriptionKey.ToString());
+	const std::string SubscriptionKey = TCHAR_TO_UTF8(*Settings->DefaultOptions.SubscriptionOptions.SubscriptionKey.ToString());
 
-	if (Settings->DefaultOptions.bUsePrivateEndpoint)
+	if (Settings->DefaultOptions.SubscriptionOptions.bUsePrivateEndpoint)
 	{
-		const std::string RegionID = TCHAR_TO_UTF8(*Settings->DefaultOptions.RegionID.ToString());
+		const std::string RegionID = TCHAR_TO_UTF8(*Settings->DefaultOptions.SubscriptionOptions.RegionID.ToString());
 		SpeechConfig = Microsoft::CognitiveServices::Speech::SpeechConfig::FromSubscription(SubscriptionKey, RegionID);
 	}
 	else
 	{
-		const std::string Endpoint = TCHAR_TO_UTF8(*Settings->DefaultOptions.PrivateEndpoint.ToString());
+		const std::string Endpoint = TCHAR_TO_UTF8(*Settings->DefaultOptions.SubscriptionOptions.PrivateEndpoint.ToString());
 		SpeechConfig = Microsoft::CognitiveServices::Speech::SpeechConfig::FromEndpoint(Endpoint, SubscriptionKey);
 	}
 

--- a/Source/AzSpeech/Private/AzSpeech/Tasks/SSMLToAudioDataAsync.cpp
+++ b/Source/AzSpeech/Private/AzSpeech/Tasks/SSMLToAudioDataAsync.cpp
@@ -10,14 +10,15 @@
 
 USSMLToAudioDataAsync* USSMLToAudioDataAsync::SSMLToAudioData_DefaultOptions(UObject* WorldContextObject, const FString& SynthesisSSML)
 {
-	return SSMLToAudioData_CustomOptions(WorldContextObject, SynthesisSSML, FAzSpeechSettingsOptions());
+	return SSMLToAudioData_CustomOptions(WorldContextObject, FAzSpeechSubscriptionOptions(), FAzSpeechSynthesisOptions(), SynthesisSSML);
 }
 
-USSMLToAudioDataAsync* USSMLToAudioDataAsync::SSMLToAudioData_CustomOptions(UObject* WorldContextObject, const FString& SynthesisSSML, const FAzSpeechSettingsOptions& Options)
+USSMLToAudioDataAsync* USSMLToAudioDataAsync::SSMLToAudioData_CustomOptions(UObject* WorldContextObject, const FAzSpeechSubscriptionOptions& SubscriptionOptions, const FAzSpeechSynthesisOptions& SynthesisOptions, const FString& SynthesisSSML)
 {
 	USSMLToAudioDataAsync* const NewAsyncTask = NewObject<USSMLToAudioDataAsync>();
 	NewAsyncTask->WorldContextObject = WorldContextObject;
-	NewAsyncTask->TaskOptions = GetValidatedOptions(Options);
+	NewAsyncTask->SubscriptionOptions = SubscriptionOptions;
+	NewAsyncTask->SynthesisOptions = SynthesisOptions;
 	NewAsyncTask->SynthesisText = SynthesisSSML;
 	NewAsyncTask->bIsSSMLBased = true;
 	NewAsyncTask->TaskName = *FString(__func__);

--- a/Source/AzSpeech/Private/AzSpeech/Tasks/SSMLToSoundWaveAsync.cpp
+++ b/Source/AzSpeech/Private/AzSpeech/Tasks/SSMLToSoundWaveAsync.cpp
@@ -12,14 +12,15 @@
 
 USSMLToSoundWaveAsync* USSMLToSoundWaveAsync::SSMLToSoundWave_DefaultOptions(UObject* WorldContextObject, const FString& SynthesisSSML)
 {
-	return SSMLToSoundWave_CustomOptions(WorldContextObject, SynthesisSSML, FAzSpeechSettingsOptions());
+	return SSMLToSoundWave_CustomOptions(WorldContextObject, FAzSpeechSubscriptionOptions(), FAzSpeechSynthesisOptions(), SynthesisSSML);
 }
 
-USSMLToSoundWaveAsync* USSMLToSoundWaveAsync::SSMLToSoundWave_CustomOptions(UObject* WorldContextObject, const FString& SynthesisSSML, const FAzSpeechSettingsOptions& Options)
+USSMLToSoundWaveAsync* USSMLToSoundWaveAsync::SSMLToSoundWave_CustomOptions(UObject* WorldContextObject, const FAzSpeechSubscriptionOptions& SubscriptionOptions, const FAzSpeechSynthesisOptions& SynthesisOptions, const FString& SynthesisSSML)
 {
 	USSMLToSoundWaveAsync* const NewAsyncTask = NewObject<USSMLToSoundWaveAsync>();
 	NewAsyncTask->WorldContextObject = WorldContextObject;
-	NewAsyncTask->TaskOptions = GetValidatedOptions(Options);
+	NewAsyncTask->SubscriptionOptions = SubscriptionOptions;
+	NewAsyncTask->SynthesisOptions = SynthesisOptions;
 	NewAsyncTask->SynthesisText = SynthesisSSML;
 	NewAsyncTask->bIsSSMLBased = true;
 	NewAsyncTask->TaskName = *FString(__func__);

--- a/Source/AzSpeech/Private/AzSpeech/Tasks/SSMLToSpeechAsync.cpp
+++ b/Source/AzSpeech/Private/AzSpeech/Tasks/SSMLToSpeechAsync.cpp
@@ -10,14 +10,15 @@
 
 USSMLToSpeechAsync* USSMLToSpeechAsync::SSMLToSpeech_DefaultOptions(UObject* WorldContextObject, const FString& SynthesisSSML)
 {
-	return SSMLToSpeech_CustomOptions(WorldContextObject, SynthesisSSML, FAzSpeechSettingsOptions());
+	return SSMLToSpeech_CustomOptions(WorldContextObject, FAzSpeechSubscriptionOptions(), FAzSpeechSynthesisOptions(), SynthesisSSML);
 }
 
-USSMLToSpeechAsync* USSMLToSpeechAsync::SSMLToSpeech_CustomOptions(UObject* WorldContextObject, const FString& SynthesisSSML, const FAzSpeechSettingsOptions& Options)
+USSMLToSpeechAsync* USSMLToSpeechAsync::SSMLToSpeech_CustomOptions(UObject* WorldContextObject, const FAzSpeechSubscriptionOptions& SubscriptionOptions, const FAzSpeechSynthesisOptions& SynthesisOptions, const FString& SynthesisSSML)
 {
 	USSMLToSpeechAsync* const NewAsyncTask = NewObject<USSMLToSpeechAsync>();
 	NewAsyncTask->WorldContextObject = WorldContextObject;
-	NewAsyncTask->TaskOptions = GetValidatedOptions(Options);
+	NewAsyncTask->SubscriptionOptions = SubscriptionOptions;
+	NewAsyncTask->SynthesisOptions = SynthesisOptions;
 	NewAsyncTask->SynthesisText = SynthesisSSML;
 	NewAsyncTask->bIsSSMLBased = true;
 	NewAsyncTask->TaskName = *FString(__func__);

--- a/Source/AzSpeech/Private/AzSpeech/Tasks/SSMLToWavFileAsync.cpp
+++ b/Source/AzSpeech/Private/AzSpeech/Tasks/SSMLToWavFileAsync.cpp
@@ -10,15 +10,16 @@
 
 USSMLToWavFileAsync* USSMLToWavFileAsync::SSMLToWavFile_DefaultOptions(UObject* WorldContextObject, const FString& SynthesisSSML, const FString& FilePath, const FString& FileName)
 {
-	return SSMLToWavFile_CustomOptions(WorldContextObject, SynthesisSSML, FilePath, FileName, FAzSpeechSettingsOptions());
+	return SSMLToWavFile_CustomOptions(WorldContextObject, FAzSpeechSubscriptionOptions(), FAzSpeechSynthesisOptions(), SynthesisSSML, FilePath, FileName);
 }
 
-USSMLToWavFileAsync* USSMLToWavFileAsync::SSMLToWavFile_CustomOptions(UObject* WorldContextObject, const FString& SynthesisSSML, const FString& FilePath, const FString& FileName, const FAzSpeechSettingsOptions& Options)
+USSMLToWavFileAsync* USSMLToWavFileAsync::SSMLToWavFile_CustomOptions(UObject* WorldContextObject, const FAzSpeechSubscriptionOptions& SubscriptionOptions, const FAzSpeechSynthesisOptions& SynthesisOptions, const FString& SynthesisSSML, const FString& FilePath, const FString& FileName)
 {
 	USSMLToWavFileAsync* const NewAsyncTask = NewObject<USSMLToWavFileAsync>();
 	NewAsyncTask->WorldContextObject = WorldContextObject;
 	NewAsyncTask->SynthesisText = SynthesisSSML;
-	NewAsyncTask->TaskOptions = GetValidatedOptions(Options);
+	NewAsyncTask->SubscriptionOptions = SubscriptionOptions;
+	NewAsyncTask->SynthesisOptions = SynthesisOptions;
 	NewAsyncTask->FilePath = FilePath;
 	NewAsyncTask->FileName = FileName;
 	NewAsyncTask->bIsSSMLBased = true;

--- a/Source/AzSpeech/Private/AzSpeech/Tasks/SpeechToTextAsync.cpp
+++ b/Source/AzSpeech/Private/AzSpeech/Tasks/SpeechToTextAsync.cpp
@@ -4,6 +4,7 @@
 
 #include "AzSpeech/Tasks/SpeechToTextAsync.h"
 #include "AzSpeech/AzSpeechHelper.h"
+#include "AzSpeechInternalFuncs.h"
 
 #ifdef UE_INLINE_GENERATED_CPP_BY_NAME
 #include UE_INLINE_GENERATED_CPP_BY_NAME(SpeechToTextAsync)
@@ -11,14 +12,15 @@
 
 USpeechToTextAsync* USpeechToTextAsync::SpeechToText_DefaultOptions(UObject* WorldContextObject, const FString& LanguageID, const FString& AudioInputDeviceID, const FName PhraseListGroup)
 {
-	return SpeechToText_CustomOptions(WorldContextObject, FAzSpeechSettingsOptions(*LanguageID), AudioInputDeviceID, PhraseListGroup);
+	return SpeechToText_CustomOptions(WorldContextObject, FAzSpeechSubscriptionOptions(), FAzSpeechRecognitionOptions(*LanguageID), AudioInputDeviceID, PhraseListGroup);
 }
 
-USpeechToTextAsync* USpeechToTextAsync::SpeechToText_CustomOptions(UObject* WorldContextObject, const FAzSpeechSettingsOptions& Options, const FString& AudioInputDeviceID, const FName PhraseListGroup)
+USpeechToTextAsync* USpeechToTextAsync::SpeechToText_CustomOptions(UObject* WorldContextObject, const FAzSpeechSubscriptionOptions& SubscriptionOptions, const FAzSpeechRecognitionOptions& RecognitionOptions, const FString& AudioInputDeviceID, const FName PhraseListGroup)
 {
 	USpeechToTextAsync* const NewAsyncTask = NewObject<USpeechToTextAsync>();
 	NewAsyncTask->WorldContextObject = WorldContextObject;
-	NewAsyncTask->TaskOptions = GetValidatedOptions(Options);
+	NewAsyncTask->SubscriptionOptions = SubscriptionOptions;
+	NewAsyncTask->RecognitionOptions = RecognitionOptions;
 	NewAsyncTask->AudioInputDeviceID = AudioInputDeviceID;
 	NewAsyncTask->PhraseListGroup = PhraseListGroup;
 	NewAsyncTask->bIsSSMLBased = false;
@@ -53,7 +55,7 @@ bool USpeechToTextAsync::StartAzureTaskWork()
 		return false;
 	}
 
-	if (AzSpeech::Internal::HasEmptyParam(GetTaskOptions().LanguageID))
+	if (AzSpeech::Internal::HasEmptyParam(GetRecognitionOptions().LanguageID))
 	{
 		return false;
 	}

--- a/Source/AzSpeech/Private/AzSpeech/Tasks/TextToAudioDataAsync.cpp
+++ b/Source/AzSpeech/Private/AzSpeech/Tasks/TextToAudioDataAsync.cpp
@@ -10,15 +10,16 @@
 
 UTextToAudioDataAsync* UTextToAudioDataAsync::TextToAudioData_DefaultOptions(UObject* WorldContextObject, const FString& SynthesisText, const FString& VoiceName, const FString& LanguageID)
 {
-	return TextToAudioData_CustomOptions(WorldContextObject, SynthesisText, FAzSpeechSettingsOptions(*LanguageID, *VoiceName));
+	return TextToAudioData_CustomOptions(WorldContextObject, FAzSpeechSubscriptionOptions(), FAzSpeechSynthesisOptions(*LanguageID, *VoiceName), SynthesisText);
 }
 
-UTextToAudioDataAsync* UTextToAudioDataAsync::TextToAudioData_CustomOptions(UObject* WorldContextObject, const FString& SynthesisText, const FAzSpeechSettingsOptions& Options)
+UTextToAudioDataAsync* UTextToAudioDataAsync::TextToAudioData_CustomOptions(UObject* WorldContextObject, const FAzSpeechSubscriptionOptions& SubscriptionOptions, const FAzSpeechSynthesisOptions& SynthesisOptions, const FString& SynthesisText)
 {
 	UTextToAudioDataAsync* const NewAsyncTask = NewObject<UTextToAudioDataAsync>();
 	NewAsyncTask->WorldContextObject = WorldContextObject;
 	NewAsyncTask->SynthesisText = SynthesisText;
-	NewAsyncTask->TaskOptions = GetValidatedOptions(Options);
+	NewAsyncTask->SubscriptionOptions = SubscriptionOptions;
+	NewAsyncTask->SynthesisOptions = SynthesisOptions;
 	NewAsyncTask->bIsSSMLBased = false;
 	NewAsyncTask->TaskName = *FString(__func__);
 	NewAsyncTask->RegisterWithGameInstance(WorldContextObject);

--- a/Source/AzSpeech/Private/AzSpeech/Tasks/TextToSoundWaveAsync.cpp
+++ b/Source/AzSpeech/Private/AzSpeech/Tasks/TextToSoundWaveAsync.cpp
@@ -12,15 +12,16 @@
 
 UTextToSoundWaveAsync* UTextToSoundWaveAsync::TextToSoundWave_DefaultOptions(UObject* WorldContextObject, const FString& SynthesisText, const FString& VoiceName, const FString& LanguageID)
 {
-	return TextToSoundWave_CustomOptions(WorldContextObject, SynthesisText, FAzSpeechSettingsOptions(*LanguageID, *VoiceName));
+	return TextToSoundWave_CustomOptions(WorldContextObject, FAzSpeechSubscriptionOptions(), FAzSpeechSynthesisOptions(*LanguageID, *VoiceName), SynthesisText);
 }
 
-UTextToSoundWaveAsync* UTextToSoundWaveAsync::TextToSoundWave_CustomOptions(UObject* WorldContextObject, const FString& SynthesisText, const FAzSpeechSettingsOptions& Options)
+UTextToSoundWaveAsync* UTextToSoundWaveAsync::TextToSoundWave_CustomOptions(UObject* WorldContextObject, const FAzSpeechSubscriptionOptions& SubscriptionOptions, const FAzSpeechSynthesisOptions& SynthesisOptions, const FString& SynthesisText)
 {
 	UTextToSoundWaveAsync* const NewAsyncTask = NewObject<UTextToSoundWaveAsync>();
 	NewAsyncTask->WorldContextObject = WorldContextObject;
 	NewAsyncTask->SynthesisText = SynthesisText;
-	NewAsyncTask->TaskOptions = GetValidatedOptions(Options);
+	NewAsyncTask->SubscriptionOptions = SubscriptionOptions;
+	NewAsyncTask->SynthesisOptions = SynthesisOptions;
 	NewAsyncTask->bIsSSMLBased = false;
 	NewAsyncTask->TaskName = *FString(__func__);
 	NewAsyncTask->RegisterWithGameInstance(WorldContextObject);

--- a/Source/AzSpeech/Private/AzSpeech/Tasks/TextToSpeechAsync.cpp
+++ b/Source/AzSpeech/Private/AzSpeech/Tasks/TextToSpeechAsync.cpp
@@ -10,15 +10,16 @@
 
 UTextToSpeechAsync* UTextToSpeechAsync::TextToSpeech_DefaultOptions(UObject* WorldContextObject, const FString& SynthesisText, const FString& VoiceName, const FString& LanguageID)
 {
-	return TextToSpeech_CustomOptions(WorldContextObject, SynthesisText, FAzSpeechSettingsOptions(*LanguageID, *VoiceName));
+	return TextToSpeech_CustomOptions(WorldContextObject, FAzSpeechSubscriptionOptions(), FAzSpeechSynthesisOptions(*LanguageID, *VoiceName), SynthesisText);
 }
 
-UTextToSpeechAsync* UTextToSpeechAsync::TextToSpeech_CustomOptions(UObject* WorldContextObject, const FString& SynthesisText, const FAzSpeechSettingsOptions& Options)
+UTextToSpeechAsync* UTextToSpeechAsync::TextToSpeech_CustomOptions(UObject* WorldContextObject, const FAzSpeechSubscriptionOptions& SubscriptionOptions, const FAzSpeechSynthesisOptions& SynthesisOptions, const FString& SynthesisText)
 {
 	UTextToSpeechAsync* const NewAsyncTask = NewObject<UTextToSpeechAsync>();
 	NewAsyncTask->WorldContextObject = WorldContextObject;
 	NewAsyncTask->SynthesisText = SynthesisText;
-	NewAsyncTask->TaskOptions = GetValidatedOptions(Options);
+	NewAsyncTask->SubscriptionOptions = SubscriptionOptions;
+	NewAsyncTask->SynthesisOptions = SynthesisOptions;
 	NewAsyncTask->bIsSSMLBased = false;
 	NewAsyncTask->TaskName = *FString(__func__);
 	NewAsyncTask->RegisterWithGameInstance(WorldContextObject);

--- a/Source/AzSpeech/Private/AzSpeech/Tasks/TextToWavFileAsync.cpp
+++ b/Source/AzSpeech/Private/AzSpeech/Tasks/TextToWavFileAsync.cpp
@@ -10,15 +10,16 @@
 
 UTextToWavFileAsync* UTextToWavFileAsync::TextToWavFile_DefaultOptions(UObject* WorldContextObject, const FString& SynthesisText, const FString& FilePath, const FString& FileName, const FString& VoiceName, const FString& LanguageID)
 {
-	return TextToWavFile_CustomOptions(WorldContextObject, SynthesisText, FilePath, FileName, FAzSpeechSettingsOptions(*LanguageID, *VoiceName));
+	return TextToWavFile_CustomOptions(WorldContextObject, FAzSpeechSubscriptionOptions(), FAzSpeechSynthesisOptions(*LanguageID, *VoiceName), SynthesisText, FilePath, FileName);
 }
 
-UTextToWavFileAsync* UTextToWavFileAsync::TextToWavFile_CustomOptions(UObject* WorldContextObject, const FString& SynthesisText, const FString& FilePath, const FString& FileName, const FAzSpeechSettingsOptions& Options)
+UTextToWavFileAsync* UTextToWavFileAsync::TextToWavFile_CustomOptions(UObject* WorldContextObject, const FAzSpeechSubscriptionOptions& SubscriptionOptions, const FAzSpeechSynthesisOptions& SynthesisOptions, const FString& SynthesisText, const FString& FilePath, const FString& FileName)
 {
 	UTextToWavFileAsync* const NewAsyncTask = NewObject<UTextToWavFileAsync>();
 	NewAsyncTask->WorldContextObject = WorldContextObject;
 	NewAsyncTask->SynthesisText = SynthesisText;
-	NewAsyncTask->TaskOptions = GetValidatedOptions(Options);
+	NewAsyncTask->SubscriptionOptions = SubscriptionOptions;
+	NewAsyncTask->SynthesisOptions = SynthesisOptions;
 	NewAsyncTask->FilePath = FilePath;
 	NewAsyncTask->FileName = FileName;
 	NewAsyncTask->bIsSSMLBased = false;

--- a/Source/AzSpeech/Private/AzSpeech/Tasks/WavFileToTextAsync.cpp
+++ b/Source/AzSpeech/Private/AzSpeech/Tasks/WavFileToTextAsync.cpp
@@ -4,6 +4,7 @@
 
 #include "AzSpeech/Tasks/WavFileToTextAsync.h"
 #include "AzSpeech/AzSpeechHelper.h"
+#include "AzSpeechInternalFuncs.h"
 #include <HAL/FileManager.h>
 
 #ifdef UE_INLINE_GENERATED_CPP_BY_NAME
@@ -12,14 +13,15 @@
 
 UWavFileToTextAsync* UWavFileToTextAsync::WavFileToText_DefaultOptions(UObject* WorldContextObject, const FString& FilePath, const FString& FileName, const FString& LanguageID, const FName PhraseListGroup)
 {
-	return WavFileToText_CustomOptions(WorldContextObject, FilePath, FileName, FAzSpeechSettingsOptions(*LanguageID), PhraseListGroup);
+	return WavFileToText_CustomOptions(WorldContextObject, FAzSpeechSubscriptionOptions(), FAzSpeechRecognitionOptions(*LanguageID), FilePath, FileName, PhraseListGroup);
 }
 
-UWavFileToTextAsync* UWavFileToTextAsync::WavFileToText_CustomOptions(UObject* WorldContextObject, const FString& FilePath, const FString& FileName, const FAzSpeechSettingsOptions& Options, const FName PhraseListGroup)
+UWavFileToTextAsync* UWavFileToTextAsync::WavFileToText_CustomOptions(UObject* WorldContextObject, const FAzSpeechSubscriptionOptions& SubscriptionOptions, const FAzSpeechRecognitionOptions& RecognitionOptions, const FString& FilePath, const FString& FileName, const FName PhraseListGroup)
 {
 	UWavFileToTextAsync* const NewAsyncTask = NewObject<UWavFileToTextAsync>();
 	NewAsyncTask->WorldContextObject = WorldContextObject;
-	NewAsyncTask->TaskOptions = GetValidatedOptions(Options);
+	NewAsyncTask->SubscriptionOptions = SubscriptionOptions;
+	NewAsyncTask->RecognitionOptions = RecognitionOptions;
 	NewAsyncTask->FilePath = FilePath;
 	NewAsyncTask->FileName = FileName;
 	NewAsyncTask->PhraseListGroup = PhraseListGroup;
@@ -50,7 +52,7 @@ bool UWavFileToTextAsync::StartAzureTaskWork()
 		return false;
 	}
 	
-	if (AzSpeech::Internal::HasEmptyParam(FilePath, FileName, GetTaskOptions().LanguageID))
+	if (AzSpeech::Internal::HasEmptyParam(FilePath, FileName, GetRecognitionOptions().LanguageID))
 	{
 		return false;
 	}

--- a/Source/AzSpeech/Public/AzSpeech/AzSpeechSettings.h
+++ b/Source/AzSpeech/Public/AzSpeech/AzSpeechSettings.h
@@ -24,22 +24,12 @@ public:
 
 	static const UAzSpeechSettings* Get();
 
-	static constexpr unsigned MaxCandidateLanguages = 10u;
-
 	UPROPERTY(GlobalConfig, EditAnywhere, Category = "AzSpeech", Meta = (DisplayName = "Default Options"))
-	FAzSpeechSettingsOptions DefaultOptions;	
+	FAzSpeechSettingsOptions DefaultOptions;
 
-	/* Silence time limit in miliseconds to consider the task as Completed */
-	UPROPERTY(GlobalConfig, EditAnywhere, Category = "Tasks", Meta = (DisplayName = "Segmentation Silence Timeout in Miliseconds", ClampMin = "100", UIMin = "100", ClampMax = "5000", UIMax = "5000"))
-	int32 SegmentationSilenceTimeoutMs;
-
-	/* Silence time limit in miliseconds at the start of the task to consider the result as Canceled/NoMatch */
-	UPROPERTY(GlobalConfig, EditAnywhere, Category = "Tasks", Meta = (DisplayName = "Initial Silence Timeout in Miliseconds", ClampMin = "0", UIMin = "0"))
-	int32 InitialSilenceTimeoutMs;
-
-	/* Time limit in seconds to wait for related asynchronous tasks to complete */
-	UPROPERTY(GlobalConfig, EditAnywhere, Category = "Tasks", Meta = (DisplayName = "Attempt Timeout in Seconds", ClampMin = "1", UIMin = "1", ClampMax = "600", UIMax = "600"))
-	int32 TimeOutInSeconds;
+	/* Time Out in seconds to wait for related asynchronous tasks to initialize: std::future::wait_for */
+	UPROPERTY(GlobalConfig, EditAnywhere, Category = "Thread", Meta = (DisplayName = "Task Initialization Time Out in Seconds", ClampMin = "1", UIMin = "1", ClampMax = "600", UIMax = "600"))
+	int32 TaskInitTimeOut;
 
 	/* CPU thread priority to use in created runnable threads */
 	UPROPERTY(GlobalConfig, EditAnywhere, Category = "Thread", Meta = (DisplayName = "Thread Priority"))
@@ -120,5 +110,5 @@ private:
 
 public:
 	static const bool CheckAzSpeechSettings();
-	static const bool CheckAzSpeechSettings(const FAzSpeechSettingsOptions& Options, const bool bSSML = false);
+	static const bool CheckAzSpeechSettings(const FAzSpeechSubscriptionOptions& Options);
 };

--- a/Source/AzSpeech/Public/AzSpeech/Runnables/Bases/AzSpeechRunnableBase.h
+++ b/Source/AzSpeech/Public/AzSpeech/Runnables/Bases/AzSpeechRunnableBase.h
@@ -52,9 +52,10 @@ protected:
 
 	virtual const bool ApplySDKSettings(const std::shared_ptr<Microsoft::CognitiveServices::Speech::SpeechConfig>& InSpeechConfig) const;
 
-	const bool EnableLogInConfiguration(const std::shared_ptr<Microsoft::CognitiveServices::Speech::SpeechConfig>& InSpeechConfig) const;
+	void InsertProfanityFilterProperty(const EAzSpeechProfanityFilter& Mode, const std::shared_ptr<Microsoft::CognitiveServices::Speech::SpeechConfig>& InSpeechConfig) const;
+	void InsertLanguageIdentificationProperty(const EAzSpeechLanguageIdentificationMode& Mode, const std::shared_ptr<Microsoft::CognitiveServices::Speech::SpeechConfig>& InSpeechConfig) const;
 
-	const Microsoft::CognitiveServices::Speech::ProfanityOption GetProfanityFilter() const;
+	const bool EnableLogInConfiguration(const std::shared_ptr<Microsoft::CognitiveServices::Speech::SpeechConfig>& InSpeechConfig) const;
 
 	const FString CancellationReasonToString(const Microsoft::CognitiveServices::Speech::CancellationReason& CancellationReason) const;
 	void ProcessCancellationError(const Microsoft::CognitiveServices::Speech::CancellationErrorCode& ErrorCode, const std::string& ErrorDetails) const;

--- a/Source/AzSpeech/Public/AzSpeech/Tasks/Bases/AzSpeechRecognizerTaskBase.h
+++ b/Source/AzSpeech/Public/AzSpeech/Tasks/Bases/AzSpeechRecognizerTaskBase.h
@@ -44,6 +44,9 @@ public:
 	FAzSpeechTaskGenericDelegate RecognitionFailed;
 
 	UFUNCTION(BlueprintPure, Category = "AzSpeech")
+	const FAzSpeechRecognitionOptions GetRecognitionOptions() const;
+
+	UFUNCTION(BlueprintPure, Category = "AzSpeech")
 	const FString GetRecognizedString() const;
 	
 	UFUNCTION(BlueprintPure, Category = "AzSpeech")
@@ -51,6 +54,7 @@ public:
 	
 protected:
 	FName PhraseListGroup = NAME_None;
+	FAzSpeechRecognitionOptions RecognitionOptions;
 	
 	void StartRecognitionWork(const std::shared_ptr<Microsoft::CognitiveServices::Speech::Audio::AudioConfig>& InAudioConfig);
 

--- a/Source/AzSpeech/Public/AzSpeech/Tasks/Bases/AzSpeechSynthesizerTaskBase.h
+++ b/Source/AzSpeech/Public/AzSpeech/Tasks/Bases/AzSpeechSynthesizerTaskBase.h
@@ -72,6 +72,9 @@ public:
 	UFUNCTION(BlueprintPure, Category = "AzSpeech")
 	const FString GetSynthesisText() const;
 
+	UFUNCTION(BlueprintPure, Category = "AzSpeech")
+	const FAzSpeechSynthesisOptions GetSynthesisOptions() const;
+
 	UFUNCTION(BlueprintPure, Category = "AzSpeech", Meta = (DisplayName = "Is SSML Based"))
 	const bool IsSSMLBased() const;
 
@@ -92,6 +95,7 @@ public:
 	
 protected:
 	FString SynthesisText;
+	FAzSpeechSynthesisOptions SynthesisOptions;
 	
 	void StartSynthesisWork(const std::shared_ptr<Microsoft::CognitiveServices::Speech::Audio::AudioConfig>& InAudioConfig);
 	

--- a/Source/AzSpeech/Public/AzSpeech/Tasks/Bases/AzSpeechTaskBase.h
+++ b/Source/AzSpeech/Public/AzSpeech/Tasks/Bases/AzSpeechTaskBase.h
@@ -36,20 +36,18 @@ public:
 	virtual void StopAzSpeechTask();
 
 	UFUNCTION(BlueprintPure, Category = "AzSpeech")
-	const bool IsUsingAutoLanguage() const;
-
-	UFUNCTION(BlueprintPure, Category = "AzSpeech")
 	const FName GetTaskName() const;
 
 	UFUNCTION(BlueprintPure, Category = "AzSpeech")
-	const FAzSpeechSettingsOptions GetTaskOptions() const;
+	const FAzSpeechSubscriptionOptions GetSubscriptionOptions() const;
 
 	virtual void SetReadyToDestroy() override;
 
 protected:
 	TSharedPtr<class FAzSpeechRunnableBase> RunnableTask;
 	FName TaskName = NAME_None;
-	FAzSpeechSettingsOptions TaskOptions;
+
+	FAzSpeechSubscriptionOptions SubscriptionOptions;
 
 	const UObject* WorldContextObject;
 	bool bIsSSMLBased = false;
@@ -64,8 +62,6 @@ protected:
 
 	bool bEndingPIE = false;
 #endif
-
-	static FAzSpeechSettingsOptions GetValidatedOptions(const FAzSpeechSettingsOptions& Options);
 
 	template <typename ReturnTy, typename ResultType>
 	constexpr ReturnTy GetProperty(const ResultType& Result, const Microsoft::CognitiveServices::Speech::PropertyId& ID)
@@ -103,9 +99,6 @@ protected:
 private:
 	bool bIsTaskActive = false;
 	bool bIsReadyToDestroy = false;
-
-	static FName GetValidatedLanguageID(const FName& Language);
-	static FName GetValidatedVoiceName(const FName& Voice);
 };
 
 UCLASS(NotPlaceable, Category = "AzSpeech")

--- a/Source/AzSpeech/Public/AzSpeech/Tasks/SSMLToAudioDataAsync.h
+++ b/Source/AzSpeech/Public/AzSpeech/Tasks/SSMLToAudioDataAsync.h
@@ -27,7 +27,7 @@ public:
 
 	/* Creates a SSML-To-AudioData task that will convert your SSML file to a audio data */
 	UFUNCTION(BlueprintCallable, Category = "AzSpeech | Custom", meta = (BlueprintInternalUseOnly = "true", WorldContext = "WorldContextObject", DisplayName = "SSML To Audio Data with Custom Options"))
-	static USSMLToAudioDataAsync* SSMLToAudioData_CustomOptions(UObject* WorldContextObject, const FString& SynthesisSSML, const FAzSpeechSettingsOptions& Options);
+	static USSMLToAudioDataAsync* SSMLToAudioData_CustomOptions(UObject* WorldContextObject, const FAzSpeechSubscriptionOptions& SubscriptionOptions, const FAzSpeechSynthesisOptions& SynthesisOptions, const FString& SynthesisSSML);
 	
 protected:
 	virtual void BroadcastFinalResult() override;

--- a/Source/AzSpeech/Public/AzSpeech/Tasks/SSMLToSoundWaveAsync.h
+++ b/Source/AzSpeech/Public/AzSpeech/Tasks/SSMLToSoundWaveAsync.h
@@ -27,7 +27,7 @@ public:
 
 	/* Creates a SSML-To-SoundWave task that will convert your SSML file to a USoundWave */
 	UFUNCTION(BlueprintCallable, Category = "AzSpeech | Custom", meta = (BlueprintInternalUseOnly = "true", WorldContext = "WorldContextObject", DisplayName = "SSML To Sound Wave with Custom Options"))
-	static USSMLToSoundWaveAsync* SSMLToSoundWave_CustomOptions(UObject* WorldContextObject, const FString& SynthesisSSML, const FAzSpeechSettingsOptions& Options);
+	static USSMLToSoundWaveAsync* SSMLToSoundWave_CustomOptions(UObject* WorldContextObject, const FAzSpeechSubscriptionOptions& SubscriptionOptions, const FAzSpeechSynthesisOptions& SynthesisOptions, const FString& SynthesisSSML);
 
 protected:
 	virtual void BroadcastFinalResult() override;

--- a/Source/AzSpeech/Public/AzSpeech/Tasks/SSMLToSpeechAsync.h
+++ b/Source/AzSpeech/Public/AzSpeech/Tasks/SSMLToSpeechAsync.h
@@ -23,5 +23,5 @@ public:
 
 	/* Creates a SSML-To-Speech task that will convert your SSML file to speech */
 	UFUNCTION(BlueprintCallable, Category = "AzSpeech | Custom", meta = (BlueprintInternalUseOnly = "true", WorldContext = "WorldContextObject", DisplayName = "SSML To Speech with Custom Options"))
-	static USSMLToSpeechAsync* SSMLToSpeech_CustomOptions(UObject* WorldContextObject, const FString& SynthesisSSML, const FAzSpeechSettingsOptions& Options);
+	static USSMLToSpeechAsync* SSMLToSpeech_CustomOptions(UObject* WorldContextObject, const FAzSpeechSubscriptionOptions& SubscriptionOptions, const FAzSpeechSynthesisOptions& SynthesisOptions, const FString& SynthesisSSML);
 };

--- a/Source/AzSpeech/Public/AzSpeech/Tasks/SSMLToWavFileAsync.h
+++ b/Source/AzSpeech/Public/AzSpeech/Tasks/SSMLToWavFileAsync.h
@@ -23,5 +23,5 @@ public:
 
 	/* Creates a Text-To-WavFile task that will convert your string to a .wav audio file */
 	UFUNCTION(BlueprintCallable, Category = "AzSpeech | Custom", meta = (BlueprintInternalUseOnly = "true", WorldContext = "WorldContextObject", DisplayName = "SSML To .wav File with Custom Options"))
-	static USSMLToWavFileAsync* SSMLToWavFile_CustomOptions(UObject* WorldContextObject, const FString& SynthesisSSML, const FString& FilePath, const FString& FileName, const FAzSpeechSettingsOptions& Options);
+	static USSMLToWavFileAsync* SSMLToWavFile_CustomOptions(UObject* WorldContextObject, const FAzSpeechSubscriptionOptions& SubscriptionOptions, const FAzSpeechSynthesisOptions& SynthesisOptions, const FString& SynthesisSSML, const FString& FilePath, const FString& FileName);
 };

--- a/Source/AzSpeech/Public/AzSpeech/Tasks/SpeechToTextAsync.h
+++ b/Source/AzSpeech/Public/AzSpeech/Tasks/SpeechToTextAsync.h
@@ -23,7 +23,7 @@ public:
 
 	/* Creates a Speech-To-Text task that will convert your speech to string */
 	UFUNCTION(BlueprintCallable, Category = "AzSpeech | Custom", meta = (BlueprintInternalUseOnly = "true", WorldContext = "WorldContextObject", DisplayName = "Speech to Text with Custom Options"))
-	static USpeechToTextAsync* SpeechToText_CustomOptions(UObject* WorldContextObject, const FAzSpeechSettingsOptions& Options, const FString& AudioInputDeviceID = "Default", const FName PhraseListGroup = NAME_None);
+	static USpeechToTextAsync* SpeechToText_CustomOptions(UObject* WorldContextObject, const FAzSpeechSubscriptionOptions& SubscriptionOptions, const FAzSpeechRecognitionOptions& RecognitionOptions, const FString& AudioInputDeviceID = "Default", const FName PhraseListGroup = NAME_None);
 
 	virtual void Activate() override;
 	

--- a/Source/AzSpeech/Public/AzSpeech/Tasks/TextToAudioDataAsync.h
+++ b/Source/AzSpeech/Public/AzSpeech/Tasks/TextToAudioDataAsync.h
@@ -27,7 +27,7 @@ public:
 
 	/* Creates a Text-To-AudioData task that will convert your text to a audio data stream */
 	UFUNCTION(BlueprintCallable, Category = "AzSpeech | Custom", meta = (BlueprintInternalUseOnly = "true", WorldContext = "WorldContextObject", DisplayName = "Text To Audio Data with Custom Options"))
-	static UTextToAudioDataAsync* TextToAudioData_CustomOptions(UObject* WorldContextObject, const FString& SynthesisText, const FAzSpeechSettingsOptions& Options);
+	static UTextToAudioDataAsync* TextToAudioData_CustomOptions(UObject* WorldContextObject, const FAzSpeechSubscriptionOptions& SubscriptionOptions, const FAzSpeechSynthesisOptions& SynthesisOptions, const FString& SynthesisText);
 
 protected:
 	virtual void BroadcastFinalResult() override;

--- a/Source/AzSpeech/Public/AzSpeech/Tasks/TextToSoundWaveAsync.h
+++ b/Source/AzSpeech/Public/AzSpeech/Tasks/TextToSoundWaveAsync.h
@@ -27,7 +27,7 @@ public:
 
 	/* Creates a Text-To-SoundWave task that will convert your text to a USoundWave */
 	UFUNCTION(BlueprintCallable, Category = "AzSpeech | Custom", meta = (BlueprintInternalUseOnly = "true", WorldContext = "WorldContextObject", DisplayName = "Text To Sound Wave with Custom Options"))
-	static UTextToSoundWaveAsync* TextToSoundWave_CustomOptions(UObject* WorldContextObject, const FString& SynthesisText, const FAzSpeechSettingsOptions& Options);
+	static UTextToSoundWaveAsync* TextToSoundWave_CustomOptions(UObject* WorldContextObject, const FAzSpeechSubscriptionOptions& SubscriptionOptions, const FAzSpeechSynthesisOptions& SynthesisOptions, const FString& SynthesisText);
 
 protected:
 	virtual void BroadcastFinalResult() override;

--- a/Source/AzSpeech/Public/AzSpeech/Tasks/TextToSpeechAsync.h
+++ b/Source/AzSpeech/Public/AzSpeech/Tasks/TextToSpeechAsync.h
@@ -23,5 +23,5 @@ public:
 
 	/* Creates a Text-To-Speech task that will convert your text to speech */
 	UFUNCTION(BlueprintCallable, Category = "AzSpeech | Custom", meta = (BlueprintInternalUseOnly = "true", WorldContext = "WorldContextObject", DisplayName = "Text To Speech with Custom Options"))
-	static UTextToSpeechAsync* TextToSpeech_CustomOptions(UObject* WorldContextObject, const FString& SynthesisText, const FAzSpeechSettingsOptions& Options);
+	static UTextToSpeechAsync* TextToSpeech_CustomOptions(UObject* WorldContextObject, const FAzSpeechSubscriptionOptions& SubscriptionOptions, const FAzSpeechSynthesisOptions& SynthesisOptions, const FString& SynthesisText);
 };

--- a/Source/AzSpeech/Public/AzSpeech/Tasks/TextToWavFileAsync.h
+++ b/Source/AzSpeech/Public/AzSpeech/Tasks/TextToWavFileAsync.h
@@ -23,5 +23,5 @@ public:
 
 	/* Creates a Text-To-WavFile task that will convert your string to a .wav audio file */
 	UFUNCTION(BlueprintCallable, Category = "AzSpeech | Custom", meta = (BlueprintInternalUseOnly = "true", WorldContext = "WorldContextObject", DisplayName = "Text To .wav File with Custom Options"))
-	static UTextToWavFileAsync* TextToWavFile_CustomOptions(UObject* WorldContextObject, const FString& SynthesisText, const FString& FilePath, const FString& FileName, const FAzSpeechSettingsOptions& Options);
+	static UTextToWavFileAsync* TextToWavFile_CustomOptions(UObject* WorldContextObject, const FAzSpeechSubscriptionOptions& SubscriptionOptions, const FAzSpeechSynthesisOptions& SynthesisOptions, const FString& SynthesisText, const FString& FilePath, const FString& FileName);
 };

--- a/Source/AzSpeech/Public/AzSpeech/Tasks/WavFileToTextAsync.h
+++ b/Source/AzSpeech/Public/AzSpeech/Tasks/WavFileToTextAsync.h
@@ -23,7 +23,7 @@ public:
 
 	/* Creates a WavFile-To-Text task that will convert your Wav file to string */
 	UFUNCTION(BlueprintCallable, Category = "AzSpeech | Custom", meta = (BlueprintInternalUseOnly = "true", WorldContext = "WorldContextObject", DisplayName = ".wav File To Text with Custom Options"))
-	static UWavFileToTextAsync* WavFileToText_CustomOptions(UObject* WorldContextObject, const FString& FilePath, const FString& FileName, const FAzSpeechSettingsOptions& Options, const FName PhraseListGroup = NAME_None);
+	static UWavFileToTextAsync* WavFileToText_CustomOptions(UObject* WorldContextObject, const FAzSpeechSubscriptionOptions& SubscriptionOptions, const FAzSpeechRecognitionOptions& RecognitionOptions, const FString& FilePath, const FString& FileName, const FName PhraseListGroup = NAME_None);
 
 	virtual void Activate() override;
 

--- a/Source/AzSpeechEditor/Private/SAzSpeechAudioGenerator.cpp
+++ b/Source/AzSpeechEditor/Private/SAzSpeechAudioGenerator.cpp
@@ -26,24 +26,13 @@ UAzSpeechPropertiesGetter::UAzSpeechPropertiesGetter(const FObjectInitializer& O
 
 void UAzSpeechPropertiesGetter::OnAvailableVoicesChanged(const TArray<FString>& Voices)
 {
-	if (OwningWidget)
-	{
-		OwningWidget->OnAvailableVoicesChanged(Voices);
-	}
-
+	OnAvailableVoicesUpdated.ExecuteIfBound(Voices);
 	Destroy();
 }
 
 void UAzSpeechPropertiesGetter::SynthesisCompleted(const TArray<uint8>& AudioData)
 {
-	if (OwningWidget)
-	{
-		if (USoundWave* const SoundWave = UAzSpeechHelper::ConvertAudioDataToSoundWave(AudioData, OwningWidget->Module, OwningWidget->RelativePath, OwningWidget->AssetName))
-		{
-			UGameplayStatics::PlaySound2D(GEditor->GetEditorWorldContext().World(), SoundWave);
-		}
-	}
-
+	OnAudioDataGenerated.ExecuteIfBound(AudioData);
 	Destroy();
 }
 
@@ -54,8 +43,6 @@ void UAzSpeechPropertiesGetter::TaskFail()
 
 void UAzSpeechPropertiesGetter::Destroy()
 {
-	OwningWidget = nullptr;
-
 #if ENGINE_MAJOR_VERSION >= 5
 	MarkAsGarbage();
 #else
@@ -252,7 +239,12 @@ void SAzSpeechAudioGenerator::Construct([[maybe_unused]] const FArguments&)
 void SAzSpeechAudioGenerator::UpdateAvailableVoices()
 {
 	UAzSpeechPropertiesGetter* const InternalGetter = NewObject<UAzSpeechPropertiesGetter>();
-	InternalGetter->OwningWidget = this;
+	InternalGetter->OnAvailableVoicesUpdated.BindLambda(
+		[this](TArray<FString> Voices)
+		{
+			OnAvailableVoicesChanged(Voices);
+		}
+	);
 
 	UGetAvailableVoicesAsync* const Task = UGetAvailableVoicesAsync::GetAvailableVoicesAsync(GEditor->GetEditorWorldContext().World(), Locale);
 	Task->Success.AddDynamic(InternalGetter, &UAzSpeechPropertiesGetter::OnAvailableVoicesChanged);
@@ -268,7 +260,15 @@ FReply SAzSpeechAudioGenerator::HandleGenerateAudioButtonClicked()
 	}
 
 	UAzSpeechPropertiesGetter* const InternalGetter = NewObject<UAzSpeechPropertiesGetter>();
-	InternalGetter->OwningWidget = this;
+	InternalGetter->OnAudioDataGenerated.BindLambda(
+		[this](TArray<uint8> AudioData)
+		{
+			if (USoundWave* const SoundWave = UAzSpeechHelper::ConvertAudioDataToSoundWave(AudioData, Module, RelativePath, AssetName))
+			{
+				UGameplayStatics::PlaySound2D(GEditor->GetEditorWorldContext().World(), SoundWave);
+			}
+		}
+	);
 
 	UAzSpeechAudioDataSynthesisBase* Task = nullptr;
 	if (bIsSSMLBased)

--- a/Source/AzSpeechEditor/Private/SAzSpeechAudioGenerator.cpp
+++ b/Source/AzSpeechEditor/Private/SAzSpeechAudioGenerator.cpp
@@ -273,12 +273,12 @@ FReply SAzSpeechAudioGenerator::HandleGenerateAudioButtonClicked()
 	UAzSpeechAudioDataSynthesisBase* Task = nullptr;
 	if (bIsSSMLBased)
 	{
-		Task = USSMLToAudioDataAsync::SSMLToAudioData_CustomOptions(GEditor->GetEditorWorldContext().World(), SynthesisText.ToString(), FAzSpeechSettingsOptions());
+		Task = USSMLToAudioDataAsync::SSMLToAudioData_DefaultOptions(GEditor->GetEditorWorldContext().World(), SynthesisText.ToString());
 		Cast<USSMLToAudioDataAsync>(Task)->SynthesisCompleted.AddDynamic(InternalGetter, &UAzSpeechPropertiesGetter::SynthesisCompleted);
 	}
 	else
 	{
-		Task = UTextToAudioDataAsync::TextToAudioData_CustomOptions(GEditor->GetEditorWorldContext().World(), SynthesisText.ToString(), FAzSpeechSettingsOptions(*Locale, *Voice));
+		Task = UTextToAudioDataAsync::TextToAudioData_DefaultOptions(GEditor->GetEditorWorldContext().World(), SynthesisText.ToString(), Voice, Locale);
 		Cast<UTextToAudioDataAsync>(Task)->SynthesisCompleted.AddDynamic(InternalGetter, &UAzSpeechPropertiesGetter::SynthesisCompleted);
 	}
 

--- a/Source/AzSpeechEditor/Private/SAzSpeechAudioGenerator.h
+++ b/Source/AzSpeechEditor/Private/SAzSpeechAudioGenerator.h
@@ -7,6 +7,9 @@
 #include <CoreMinimal.h>
 #include "SAzSpeechAudioGenerator.generated.h"
 
+DECLARE_DELEGATE_OneParam(FAvailableVoicesUpdated, TArray<FString>);
+DECLARE_DELEGATE_OneParam(FAudioDataGenerated, TArray<uint8>);
+
 UCLASS(MinimalAPI, NotBlueprintable, NotPlaceable, Category = "Implementation")
 class UAzSpeechPropertiesGetter : public UObject
 {
@@ -14,11 +17,9 @@ class UAzSpeechPropertiesGetter : public UObject
 
 public:
 	explicit UAzSpeechPropertiesGetter(const FObjectInitializer& ObjectInitializer = FObjectInitializer::Get());
-#if ENGINE_MAJOR_VERSION >= 5
-	TObjectPtr<class SAzSpeechAudioGenerator> OwningWidget;
-#else
-	class SAzSpeechAudioGenerator* OwningWidget;
-#endif
+	
+	FAvailableVoicesUpdated OnAvailableVoicesUpdated;
+	FAudioDataGenerated OnAudioDataGenerated;
 
 	UFUNCTION()
 	void OnAvailableVoicesChanged(const TArray<FString>& Voices);


### PR DESCRIPTION
## Changes
* Create new structures: FAzSpeechSubscriptionOptions, FAzSpeechRecognitionOptions & FAzSpeechSynthesisOptions
* Change members of FAzSpeechSynthesisOptions to use the new structures
* Change tasks w/ custom options param to use FAzSpeechSubscriptionOptions & (FAzSpeechRecognitionOptions | FAzSpeechSynthesisOptions)
* Separate options per task type
* Recognitions tasks now store FAzSpeechSubscriptionOptions + FAzSpeechRecognitionOptions 
* Synthesis tasks now store FAzSpeechSubscriptionOptions + FAzSpeechSynthesisOptions
* Add new options: Language Identification Mode
* Adjust Audio Generator Tool Data Updates

## Notes
* Some changes will break some input params of **tasks with custom options** due to the different structure type and addition of one more param: Theses tasks will now receive Subscription Options + Recognition|Synthesis Options

# Screenshots
## New Structures & Modified Task Params + Modified Settings/Options
![image](https://user-images.githubusercontent.com/77353979/228281114-f11f5808-3ada-412e-a891-4d2826fffc00.png)

## Settings Page
![image](https://user-images.githubusercontent.com/77353979/228293985-fb9f78f4-6eff-453b-a839-891235c30487.png)