### PR TITLE
v1.6.5

### DIFF
--- a/AzSpeech.uplugin
+++ b/AzSpeech.uplugin
@@ -1,7 +1,7 @@
 {
 	"FileVersion": 3,
-	"Version": 21,
-	"VersionName": "1.6.4",
+	"Version": 22,
+	"VersionName": "1.6.5",
 	"FriendlyName": "AzSpeech - Voice and Text",
 	"Description": "Integrates Azure Speech Cognitive Services into the Engine by adding functions to perform recognition and synthesis via asynchronous tasks.",
 	"Category": "Game Features",

--- a/Config/DefaultAzSpeech.ini
+++ b/Config/DefaultAzSpeech.ini
@@ -162,9 +162,27 @@
 +PropertyRedirects=(OldName="AzSpeechHelper.ConvertWavFileToSoundWave.OutputModulePath", NewName="AzSpeechHelper.ConvertWavFileToSoundWave.OutputModule")
 +PropertyRedirects=(OldName="AzSpeechHelper.ConvertAudioDataToSoundWave.OutputModulePath", NewName="AzSpeechHelper.ConvertAudioDataToSoundWave.OutputModule")
 
-; v1.6.4
+; v1.6.5
 ; Properties
 +PropertyRedirects=(OldName="AzSpeechSettingsOptions.SubscriptionKey", NewName="AzSpeechSettingsOptions.SubscriptionOptions.SubscriptionKey")
 +PropertyRedirects=(OldName="AzSpeechSettingsOptions.RegionID", NewName="AzSpeechSettingsOptions.SubscriptionOptions.RegionID")
 +PropertyRedirects=(OldName="AzSpeechSettingsOptions.bUsePrivateEndpoint", NewName="AzSpeechSettingsOptions.SubscriptionOptions.bUsePrivateEndpoint")
 +PropertyRedirects=(OldName="AzSpeechSettingsOptions.PrivateEndpoint", NewName="AzSpeechSettingsOptions.SubscriptionOptions.PrivateEndpoint")
+
+; v1.6.6
+; Functions params
++PropertyRedirects=(OldName="SpeechToTextAsync.SpeechToText_DefaultOptions.LanguageID", NewName="SpeechToTextAsync.SpeechToText_DefaultOptions.Locale")
++PropertyRedirects=(OldName="WavFileToTextAsync.WavFileToText_DefaultOptions.LanguageID", NewName="WavFileToTextAsync.WavFileToText_DefaultOptions.Locale")
++PropertyRedirects=(OldName="TextToSpeechAsync.TextToSpeech_DefaultOptions.VoiceName", NewName="TextToSpeechAsync.TextToSpeech_DefaultOptions.Voice")
++PropertyRedirects=(OldName="TextToSpeechAsync.TextToSpeech_DefaultOptions.LanguageID", NewName="TextToSpeechAsync.TextToSpeech_DefaultOptions.Locale")
++PropertyRedirects=(OldName="TextToSoundWaveAsync.TextToSoundWave_DefaultOptions.VoiceName", NewName="TextToSoundWaveAsync.TextToSoundWave_DefaultOptions.Voice")
++PropertyRedirects=(OldName="TextToSoundWaveAsync.TextToSoundWave_DefaultOptions.LanguageID", NewName="TextToSoundWaveAsync.TextToSoundWave_DefaultOptions.Locale")
++PropertyRedirects=(OldName="TextToWavFileAsync.TextToWavFile_DefaultOptions.VoiceName", NewName="TextToWavFileAsync.TextToWavFile_DefaultOptions.Voice")
++PropertyRedirects=(OldName="TextToWavFileAsync.TextToWavFile_DefaultOptions.LanguageID", NewName="TextToWavFileAsync.TextToWavFile_DefaultOptions.Locale")
++PropertyRedirects=(OldName="TextToAudioDataAsync.TextToAudioData_DefaultOptions.VoiceName", NewName="TextToAudioDataAsync.TextToAudioData_DefaultOptions.Voice")
++PropertyRedirects=(OldName="TextToAudioDataAsync.TextToAudioData_DefaultOptions.LanguageID", NewName="TextToAudioDataAsync.TextToAudioData_DefaultOptions.Locale")
+
+; Properties
++PropertyRedirects=(OldName="AzSpeechRecognitionOptions.LanguageID", NewName="AzSpeechRecognitionOptions.Locale")
++PropertyRedirects=(OldName="AzSpeechSynthesisOptions.LanguageID", NewName="AzSpeechSynthesisOptions.Locale")
++PropertyRedirects=(OldName="AzSpeechSynthesisOptions.VoiceName", NewName="AzSpeechSynthesisOptions.Voice")

--- a/Source/AzSpeech/Private/AzSpeech/AzSpeechSettings.cpp
+++ b/Source/AzSpeech/Private/AzSpeech/AzSpeechSettings.cpp
@@ -65,9 +65,9 @@ void UAzSpeechSettings::PreEditChange(FProperty* PropertyAboutToChange)
 {
 	Super::PreEditChange(PropertyAboutToChange);
 
-	if (PropertyAboutToChange->GetFName() == GET_MEMBER_NAME_CHECKED(FAzSpeechRecognitionOptions, LanguageID))
+	if (PropertyAboutToChange->GetFName() == GET_MEMBER_NAME_CHECKED(FAzSpeechRecognitionOptions, Locale))
 	{
-		DefaultOptions.RecognitionOptions.CandidateLanguages.Remove(DefaultOptions.RecognitionOptions.LanguageID);
+		DefaultOptions.RecognitionOptions.CandidateLanguages.Remove(DefaultOptions.RecognitionOptions.Locale);
 	}
 }
 
@@ -75,7 +75,7 @@ void UAzSpeechSettings::PostEditChangeProperty(FPropertyChangedEvent& PropertyCh
 {
 	Super::PostEditChangeProperty(PropertyChangedEvent);
 
-	if (PropertyChangedEvent.Property->GetFName() == GET_MEMBER_NAME_CHECKED(FAzSpeechRecognitionOptions, CandidateLanguages) || PropertyChangedEvent.Property->GetFName() == GET_MEMBER_NAME_CHECKED(FAzSpeechRecognitionOptions, LanguageID))
+	if (PropertyChangedEvent.Property->GetFName() == GET_MEMBER_NAME_CHECKED(FAzSpeechRecognitionOptions, CandidateLanguages) || PropertyChangedEvent.Property->GetFName() == GET_MEMBER_NAME_CHECKED(FAzSpeechRecognitionOptions, Locale))
 	{
 		constexpr uint8 MaxCandidateLanguages = 10;
 
@@ -118,15 +118,15 @@ void UAzSpeechSettings::SetToDefaults()
 	DefaultOptions.SubscriptionOptions.bUsePrivateEndpoint = false;
 	DefaultOptions.SubscriptionOptions.PrivateEndpoint = NAME_None;
 
-	DefaultOptions.SynthesisOptions.LanguageID = NAME_None;
-	DefaultOptions.SynthesisOptions.VoiceName = NAME_None;
+	DefaultOptions.SynthesisOptions.Locale = NAME_None;
+	DefaultOptions.SynthesisOptions.Voice = NAME_None;
 	DefaultOptions.SynthesisOptions.bEnableViseme = true;
 	DefaultOptions.SynthesisOptions.SpeechSynthesisOutputFormat = EAzSpeechSynthesisOutputFormat::Riff16Khz16BitMonoPcm;
 	DefaultOptions.SynthesisOptions.bUseLanguageIdentification = false;
 	DefaultOptions.SynthesisOptions.ProfanityFilter = EAzSpeechProfanityFilter::Raw;
 	DefaultOptions.SynthesisOptions.LanguageIdentificationMode = EAzSpeechLanguageIdentificationMode::AtStart;
 
-	DefaultOptions.RecognitionOptions.LanguageID = NAME_None;
+	DefaultOptions.RecognitionOptions.Locale = NAME_None;
 	DefaultOptions.RecognitionOptions.SpeechRecognitionOutputFormat = EAzSpeechRecognitionOutputFormat::Detailed;
 	DefaultOptions.RecognitionOptions.bUseLanguageIdentification = false;
 	DefaultOptions.RecognitionOptions.ProfanityFilter = EAzSpeechProfanityFilter::Raw;
@@ -136,7 +136,7 @@ void UAzSpeechSettings::SetToDefaults()
 
 	if (AzSpeech::Internal::HasEmptyParam(DefaultOptions.RecognitionOptions.CandidateLanguages))
 	{
-		DefaultOptions.RecognitionOptions.CandidateLanguages.Add(DefaultOptions.RecognitionOptions.LanguageID);
+		DefaultOptions.RecognitionOptions.CandidateLanguages.Add(DefaultOptions.RecognitionOptions.Locale);
 	}
 }
 
@@ -162,9 +162,9 @@ void UAzSpeechSettings::ValidateCandidateLanguages(const bool bRemoveEmpties)
 		DefaultOptions.RecognitionOptions.CandidateLanguages.Remove(NAME_None);
 	}
 
-	if (!DefaultOptions.RecognitionOptions.CandidateLanguages.Contains(DefaultOptions.RecognitionOptions.LanguageID))
+	if (!DefaultOptions.RecognitionOptions.CandidateLanguages.Contains(DefaultOptions.RecognitionOptions.Locale))
 	{
-		DefaultOptions.RecognitionOptions.CandidateLanguages.Insert(DefaultOptions.RecognitionOptions.LanguageID, 0);
+		DefaultOptions.RecognitionOptions.CandidateLanguages.Insert(DefaultOptions.RecognitionOptions.Locale, 0);
 	}
 
 	DefaultOptions.RecognitionOptions.CandidateLanguages.Shrink();

--- a/Source/AzSpeech/Private/AzSpeech/Runnables/AzSpeechRecognitionRunnable.cpp
+++ b/Source/AzSpeech/Private/AzSpeech/Runnables/AzSpeechRecognitionRunnable.cpp
@@ -133,9 +133,9 @@ const bool FAzSpeechRecognitionRunnable::ApplySDKSettings(const std::shared_ptr<
 		return true;
 	}
 
-	UE_LOG(LogAzSpeech_Internal, Display, TEXT("Thread: %s; Function: %s; Message: Using language: %s"), *GetThreadName(), *FString(__func__), *RecognizerTask->GetRecognitionOptions().LanguageID.ToString());
+	UE_LOG(LogAzSpeech_Internal, Display, TEXT("Thread: %s; Function: %s; Message: Using language: %s"), *GetThreadName(), *FString(__func__), *RecognizerTask->GetRecognitionOptions().Locale.ToString());
 
-	const std::string UsedLang = TCHAR_TO_UTF8(*RecognizerTask->GetRecognitionOptions().LanguageID.ToString());
+	const std::string UsedLang = TCHAR_TO_UTF8(*RecognizerTask->GetRecognitionOptions().Locale.ToString());
 	InConfig->SetSpeechRecognitionLanguage(UsedLang);
 
 	return !AzSpeech::Internal::HasEmptyParam(UsedLang);

--- a/Source/AzSpeech/Private/AzSpeech/Runnables/AzSpeechSynthesisRunnable.cpp
+++ b/Source/AzSpeech/Private/AzSpeech/Runnables/AzSpeechSynthesisRunnable.cpp
@@ -135,13 +135,13 @@ const bool FAzSpeechSynthesisRunnable::ApplySDKSettings(const std::shared_ptr<Mi
 		return true;
 	}
 
-	const std::string UsedLang = TCHAR_TO_UTF8(*SynthesizerTask->GetSynthesisOptions().LanguageID.ToString());
-	const std::string UsedVoice = TCHAR_TO_UTF8(*SynthesizerTask->GetSynthesisOptions().VoiceName.ToString());
+	const std::string UsedLang = TCHAR_TO_UTF8(*SynthesizerTask->GetSynthesisOptions().Locale.ToString());
+	const std::string UsedVoice = TCHAR_TO_UTF8(*SynthesizerTask->GetSynthesisOptions().Voice.ToString());
 
-	UE_LOG(LogAzSpeech_Internal, Display, TEXT("Thread: %s; Function: %s; Message: Using language: %s"), *GetThreadName(), *FString(__func__), *SynthesizerTask->GetSynthesisOptions().LanguageID.ToString());
+	UE_LOG(LogAzSpeech_Internal, Display, TEXT("Thread: %s; Function: %s; Message: Using language: %s"), *GetThreadName(), *FString(__func__), *SynthesizerTask->GetSynthesisOptions().Locale.ToString());
 	InConfig->SetSpeechSynthesisLanguage(UsedLang);
 
-	UE_LOG(LogAzSpeech_Internal, Display, TEXT("Thread: %s; Function: %s; Message: Using voice: %s"), *GetThreadName(), *FString(__func__), *SynthesizerTask->GetSynthesisOptions().VoiceName.ToString());
+	UE_LOG(LogAzSpeech_Internal, Display, TEXT("Thread: %s; Function: %s; Message: Using voice: %s"), *GetThreadName(), *FString(__func__), *SynthesizerTask->GetSynthesisOptions().Voice.ToString());
 	InConfig->SetSpeechSynthesisVoiceName(UsedVoice);
 
 	return true;

--- a/Source/AzSpeech/Private/AzSpeech/Runnables/Bases/AzSpeechRunnableBase.cpp
+++ b/Source/AzSpeech/Private/AzSpeech/Runnables/Bases/AzSpeechRunnableBase.cpp
@@ -66,7 +66,7 @@ void FAzSpeechRunnableBase::Exit()
 	UE_LOG(LogAzSpeech_Internal, Display, TEXT("Thread: %s; Function: %s; Message: Exiting thread"), *GetThreadName(), *FString(__func__));
 
 	UAzSpeechTaskBase* const Task = GetOwningTask();
-	if (!Task)
+	if (!UAzSpeechTaskStatus::IsTaskActive(Task))
 	{
 		return;
 	}

--- a/Source/AzSpeech/Private/AzSpeech/Structures/AzSpeechSettingsOptions.cpp
+++ b/Source/AzSpeech/Private/AzSpeech/Structures/AzSpeechSettingsOptions.cpp
@@ -63,21 +63,21 @@ FAzSpeechRecognitionOptions::FAzSpeechRecognitionOptions()
 	SetDefaults();
 }
 
-FAzSpeechRecognitionOptions::FAzSpeechRecognitionOptions(const FName& LanguageID)
+FAzSpeechRecognitionOptions::FAzSpeechRecognitionOptions(const FName& Locale)
 {
 	SetDefaults();
 
-	if (IsAutoLanguage(LanguageID))
+	if (IsAutoLanguage(Locale))
 	{
 		this->bUseLanguageIdentification = true;
-		this->LanguageID = LanguageID;
+		this->Locale = Locale;
 	}
-	else if (IsDefault(LanguageID))
+	else if (IsDefault(Locale))
 	{
-		this->LanguageID = GetDefault<UAzSpeechSettings>()->DefaultOptions.RecognitionOptions.LanguageID;
+		this->Locale = GetDefault<UAzSpeechSettings>()->DefaultOptions.RecognitionOptions.Locale;
 	}
 
-	this->LanguageID = LanguageID;
+	this->Locale = Locale;
 }
 
 uint8 FAzSpeechRecognitionOptions::GetMaxAllowedCandidateLanguages() const
@@ -101,7 +101,7 @@ void FAzSpeechRecognitionOptions::SetDefaults()
 {
 	if (const UAzSpeechSettings* const Settings = GetDefault<UAzSpeechSettings>())
 	{
-		LanguageID = Settings->DefaultOptions.RecognitionOptions.LanguageID;
+		Locale = Settings->DefaultOptions.RecognitionOptions.Locale;
 		CandidateLanguages = Settings->DefaultOptions.RecognitionOptions.CandidateLanguages;
 		SpeechRecognitionOutputFormat = Settings->DefaultOptions.RecognitionOptions.SpeechRecognitionOutputFormat;
 		bUseLanguageIdentification = Settings->DefaultOptions.RecognitionOptions.bUseLanguageIdentification;
@@ -117,47 +117,47 @@ FAzSpeechSynthesisOptions::FAzSpeechSynthesisOptions()
 	SetDefaults();
 }
 
-FAzSpeechSynthesisOptions::FAzSpeechSynthesisOptions(const FName& LanguageID)
+FAzSpeechSynthesisOptions::FAzSpeechSynthesisOptions(const FName& Locale)
 {
 	SetDefaults();
 
-	if (IsAutoLanguage(LanguageID))
+	if (IsAutoLanguage(Locale))
 	{
 		this->bUseLanguageIdentification = true;
-		this->LanguageID = LanguageID;
+		this->Locale = Locale;
 	}
-	else if (IsDefault(LanguageID))
+	else if (IsDefault(Locale))
 	{
-		this->LanguageID = GetDefault<UAzSpeechSettings>()->DefaultOptions.SynthesisOptions.LanguageID;
+		this->Locale = GetDefault<UAzSpeechSettings>()->DefaultOptions.SynthesisOptions.Locale;
 	}
 
-	this->LanguageID = LanguageID;
+	this->Locale = Locale;
 }
 
-FAzSpeechSynthesisOptions::FAzSpeechSynthesisOptions(const FName& LanguageID, const FName& VoiceName)
+FAzSpeechSynthesisOptions::FAzSpeechSynthesisOptions(const FName& Locale, const FName& Voice)
 {
 	SetDefaults();
 
-	if (IsAutoLanguage(LanguageID))
+	if (IsAutoLanguage(Locale))
 	{
 		this->bUseLanguageIdentification = true;
-		this->LanguageID = LanguageID;
+		this->Locale = Locale;
 	}
-	else if (IsDefault(LanguageID))
+	else if (IsDefault(Locale))
 	{
-		this->LanguageID = GetDefault<UAzSpeechSettings>()->DefaultOptions.SynthesisOptions.LanguageID;
+		this->Locale = GetDefault<UAzSpeechSettings>()->DefaultOptions.SynthesisOptions.Locale;
 	}
 
-	this->LanguageID = LanguageID;
-	this->VoiceName = IsDefault(VoiceName) ? GetDefault<UAzSpeechSettings>()->DefaultOptions.SynthesisOptions.VoiceName : VoiceName;
+	this->Locale = Locale;
+	this->Voice = IsDefault(Voice) ? GetDefault<UAzSpeechSettings>()->DefaultOptions.SynthesisOptions.Voice : Voice;
 }
 
 void FAzSpeechSynthesisOptions::SetDefaults()
 {
 	if (const UAzSpeechSettings* const Settings = GetDefault<UAzSpeechSettings>())
 	{
-		LanguageID = Settings->DefaultOptions.SynthesisOptions.LanguageID;
-		VoiceName = Settings->DefaultOptions.SynthesisOptions.VoiceName;
+		Locale = Settings->DefaultOptions.SynthesisOptions.Locale;
+		Voice = Settings->DefaultOptions.SynthesisOptions.Voice;
 		bEnableViseme = Settings->DefaultOptions.SynthesisOptions.bEnableViseme;
 		SpeechSynthesisOutputFormat = Settings->DefaultOptions.SynthesisOptions.SpeechSynthesisOutputFormat;
 		bUseLanguageIdentification = Settings->DefaultOptions.SynthesisOptions.bUseLanguageIdentification;

--- a/Source/AzSpeech/Private/AzSpeech/Tasks/Bases/AzSpeechRecognizerTaskBase.cpp
+++ b/Source/AzSpeech/Private/AzSpeech/Tasks/Bases/AzSpeechRecognizerTaskBase.cpp
@@ -55,6 +55,8 @@ void UAzSpeechRecognizerTaskBase::StartRecognitionWork(const std::shared_ptr<Mic
 
 void UAzSpeechRecognizerTaskBase::BroadcastFinalResult()
 {
+	FScopeLock Lock(&Mutex);
+
 	if (!UAzSpeechTaskStatus::IsTaskActive(this))
 	{
 		return;

--- a/Source/AzSpeech/Private/AzSpeech/Tasks/Bases/AzSpeechWavFileSynthesisBase.cpp
+++ b/Source/AzSpeech/Private/AzSpeech/Tasks/Bases/AzSpeechWavFileSynthesisBase.cpp
@@ -78,7 +78,7 @@ bool UAzSpeechWavFileSynthesisBase::StartAzureTaskWork()
 		return false;
 	}
 
-	if (AzSpeech::Internal::HasEmptyParam(SynthesisText, FilePath, FileName) || (!bIsSSMLBased && AzSpeech::Internal::HasEmptyParam(GetSynthesisOptions().VoiceName, GetSynthesisOptions().LanguageID)))
+	if (AzSpeech::Internal::HasEmptyParam(SynthesisText, FilePath, FileName) || (!bIsSSMLBased && AzSpeech::Internal::HasEmptyParam(GetSynthesisOptions().Voice, GetSynthesisOptions().Locale)))
 	{
 		return false;
 	}

--- a/Source/AzSpeech/Private/AzSpeech/Tasks/GetAvailableVoicesAsync.cpp
+++ b/Source/AzSpeech/Private/AzSpeech/Tasks/GetAvailableVoicesAsync.cpp
@@ -18,9 +18,9 @@ THIRD_PARTY_INCLUDES_END
 UGetAvailableVoicesAsync* UGetAvailableVoicesAsync::GetAvailableVoicesAsync(UObject* WorldContextObject, const FString& Locale)
 {
 	UGetAvailableVoicesAsync* const NewAsyncTask = NewObject<UGetAvailableVoicesAsync>();
-	NewAsyncTask->WorldContextObject = WorldContextObject;
 	NewAsyncTask->TaskName = *FString(__func__);
 	NewAsyncTask->Locale = Locale;
+
 	NewAsyncTask->RegisterWithGameInstance(WorldContextObject);
 
 	return NewAsyncTask;

--- a/Source/AzSpeech/Private/AzSpeech/Tasks/RecognitionMapCheckAsync.cpp
+++ b/Source/AzSpeech/Private/AzSpeech/Tasks/RecognitionMapCheckAsync.cpp
@@ -15,11 +15,11 @@
 URecognitionMapCheckAsync* URecognitionMapCheckAsync::RecognitionMapCheckAsync(UObject* WorldContextObject, const FString& InString, const FName GroupName, const bool bStopAtFirstTrigger)
 {
 	URecognitionMapCheckAsync* const NewAsyncTask = NewObject<URecognitionMapCheckAsync>();
-	NewAsyncTask->WorldContextObject = WorldContextObject;
 	NewAsyncTask->InputString = InString;
 	NewAsyncTask->GroupName = GroupName;
 	NewAsyncTask->bStopAtFirstTrigger = bStopAtFirstTrigger;
 	NewAsyncTask->TaskName = *FString(__func__);
+
 	NewAsyncTask->RegisterWithGameInstance(WorldContextObject);
 
 	return NewAsyncTask;

--- a/Source/AzSpeech/Private/AzSpeech/Tasks/SSMLToAudioDataAsync.cpp
+++ b/Source/AzSpeech/Private/AzSpeech/Tasks/SSMLToAudioDataAsync.cpp
@@ -4,8 +4,22 @@
 
 #include "AzSpeech/Tasks/SSMLToAudioDataAsync.h"
 
+#if WITH_EDITOR
+#include <Editor.h>
+#endif
+
 #ifdef UE_INLINE_GENERATED_CPP_BY_NAME
 #include UE_INLINE_GENERATED_CPP_BY_NAME(SSMLToAudioDataAsync)
+#endif
+
+#if WITH_EDITOR
+USSMLToAudioDataAsync* USSMLToAudioDataAsync::EditorTask(const FString& SynthesisSSML)
+{
+	USSMLToAudioDataAsync* const NewAsyncTask = SSMLToAudioData_DefaultOptions(GEditor->GetEditorWorldContext().World(), SynthesisSSML);
+	NewAsyncTask->bIsEditorTask = true;
+
+	return NewAsyncTask;
+}
 #endif
 
 USSMLToAudioDataAsync* USSMLToAudioDataAsync::SSMLToAudioData_DefaultOptions(UObject* WorldContextObject, const FString& SynthesisSSML)
@@ -13,7 +27,7 @@ USSMLToAudioDataAsync* USSMLToAudioDataAsync::SSMLToAudioData_DefaultOptions(UOb
 	return SSMLToAudioData_CustomOptions(WorldContextObject, FAzSpeechSubscriptionOptions(), FAzSpeechSynthesisOptions(), SynthesisSSML);
 }
 
-USSMLToAudioDataAsync* USSMLToAudioDataAsync::SSMLToAudioData_CustomOptions(UObject* WorldContextObject, const FAzSpeechSubscriptionOptions& SubscriptionOptions, const FAzSpeechSynthesisOptions& SynthesisOptions, const FString& SynthesisSSML)
+USSMLToAudioDataAsync* USSMLToAudioDataAsync::SSMLToAudioData_CustomOptions(UObject* WorldContextObject, const FAzSpeechSubscriptionOptions SubscriptionOptions, const FAzSpeechSynthesisOptions SynthesisOptions, const FString& SynthesisSSML)
 {
 	USSMLToAudioDataAsync* const NewAsyncTask = NewObject<USSMLToAudioDataAsync>();
 	NewAsyncTask->WorldContextObject = WorldContextObject;
@@ -22,6 +36,7 @@ USSMLToAudioDataAsync* USSMLToAudioDataAsync::SSMLToAudioData_CustomOptions(UObj
 	NewAsyncTask->SynthesisText = SynthesisSSML;
 	NewAsyncTask->bIsSSMLBased = true;
 	NewAsyncTask->TaskName = *FString(__func__);
+
 	NewAsyncTask->RegisterWithGameInstance(WorldContextObject);
 
 	return NewAsyncTask;

--- a/Source/AzSpeech/Private/AzSpeech/Tasks/SSMLToSoundWaveAsync.cpp
+++ b/Source/AzSpeech/Private/AzSpeech/Tasks/SSMLToSoundWaveAsync.cpp
@@ -15,7 +15,7 @@ USSMLToSoundWaveAsync* USSMLToSoundWaveAsync::SSMLToSoundWave_DefaultOptions(UOb
 	return SSMLToSoundWave_CustomOptions(WorldContextObject, FAzSpeechSubscriptionOptions(), FAzSpeechSynthesisOptions(), SynthesisSSML);
 }
 
-USSMLToSoundWaveAsync* USSMLToSoundWaveAsync::SSMLToSoundWave_CustomOptions(UObject* WorldContextObject, const FAzSpeechSubscriptionOptions& SubscriptionOptions, const FAzSpeechSynthesisOptions& SynthesisOptions, const FString& SynthesisSSML)
+USSMLToSoundWaveAsync* USSMLToSoundWaveAsync::SSMLToSoundWave_CustomOptions(UObject* WorldContextObject, const FAzSpeechSubscriptionOptions SubscriptionOptions, const FAzSpeechSynthesisOptions SynthesisOptions, const FString& SynthesisSSML)
 {
 	USSMLToSoundWaveAsync* const NewAsyncTask = NewObject<USSMLToSoundWaveAsync>();
 	NewAsyncTask->WorldContextObject = WorldContextObject;
@@ -24,6 +24,7 @@ USSMLToSoundWaveAsync* USSMLToSoundWaveAsync::SSMLToSoundWave_CustomOptions(UObj
 	NewAsyncTask->SynthesisText = SynthesisSSML;
 	NewAsyncTask->bIsSSMLBased = true;
 	NewAsyncTask->TaskName = *FString(__func__);
+
 	NewAsyncTask->RegisterWithGameInstance(WorldContextObject);
 
 	return NewAsyncTask;

--- a/Source/AzSpeech/Private/AzSpeech/Tasks/SSMLToSpeechAsync.cpp
+++ b/Source/AzSpeech/Private/AzSpeech/Tasks/SSMLToSpeechAsync.cpp
@@ -13,7 +13,7 @@ USSMLToSpeechAsync* USSMLToSpeechAsync::SSMLToSpeech_DefaultOptions(UObject* Wor
 	return SSMLToSpeech_CustomOptions(WorldContextObject, FAzSpeechSubscriptionOptions(), FAzSpeechSynthesisOptions(), SynthesisSSML);
 }
 
-USSMLToSpeechAsync* USSMLToSpeechAsync::SSMLToSpeech_CustomOptions(UObject* WorldContextObject, const FAzSpeechSubscriptionOptions& SubscriptionOptions, const FAzSpeechSynthesisOptions& SynthesisOptions, const FString& SynthesisSSML)
+USSMLToSpeechAsync* USSMLToSpeechAsync::SSMLToSpeech_CustomOptions(UObject* WorldContextObject, const FAzSpeechSubscriptionOptions SubscriptionOptions, const FAzSpeechSynthesisOptions SynthesisOptions, const FString& SynthesisSSML)
 {
 	USSMLToSpeechAsync* const NewAsyncTask = NewObject<USSMLToSpeechAsync>();
 	NewAsyncTask->WorldContextObject = WorldContextObject;
@@ -22,6 +22,7 @@ USSMLToSpeechAsync* USSMLToSpeechAsync::SSMLToSpeech_CustomOptions(UObject* Worl
 	NewAsyncTask->SynthesisText = SynthesisSSML;
 	NewAsyncTask->bIsSSMLBased = true;
 	NewAsyncTask->TaskName = *FString(__func__);
+
 	NewAsyncTask->RegisterWithGameInstance(WorldContextObject);
 
 	return NewAsyncTask;

--- a/Source/AzSpeech/Private/AzSpeech/Tasks/SSMLToWavFileAsync.cpp
+++ b/Source/AzSpeech/Private/AzSpeech/Tasks/SSMLToWavFileAsync.cpp
@@ -13,10 +13,9 @@ USSMLToWavFileAsync* USSMLToWavFileAsync::SSMLToWavFile_DefaultOptions(UObject* 
 	return SSMLToWavFile_CustomOptions(WorldContextObject, FAzSpeechSubscriptionOptions(), FAzSpeechSynthesisOptions(), SynthesisSSML, FilePath, FileName);
 }
 
-USSMLToWavFileAsync* USSMLToWavFileAsync::SSMLToWavFile_CustomOptions(UObject* WorldContextObject, const FAzSpeechSubscriptionOptions& SubscriptionOptions, const FAzSpeechSynthesisOptions& SynthesisOptions, const FString& SynthesisSSML, const FString& FilePath, const FString& FileName)
+USSMLToWavFileAsync* USSMLToWavFileAsync::SSMLToWavFile_CustomOptions(UObject* WorldContextObject, const FAzSpeechSubscriptionOptions SubscriptionOptions, const FAzSpeechSynthesisOptions SynthesisOptions, const FString& SynthesisSSML, const FString& FilePath, const FString& FileName)
 {
 	USSMLToWavFileAsync* const NewAsyncTask = NewObject<USSMLToWavFileAsync>();
-	NewAsyncTask->WorldContextObject = WorldContextObject;
 	NewAsyncTask->SynthesisText = SynthesisSSML;
 	NewAsyncTask->SubscriptionOptions = SubscriptionOptions;
 	NewAsyncTask->SynthesisOptions = SynthesisOptions;
@@ -24,6 +23,7 @@ USSMLToWavFileAsync* USSMLToWavFileAsync::SSMLToWavFile_CustomOptions(UObject* W
 	NewAsyncTask->FileName = FileName;
 	NewAsyncTask->bIsSSMLBased = true;
 	NewAsyncTask->TaskName = *FString(__func__);
+
 	NewAsyncTask->RegisterWithGameInstance(WorldContextObject);
 
 	return NewAsyncTask;

--- a/Source/AzSpeech/Private/AzSpeech/Tasks/SpeechToTextAsync.cpp
+++ b/Source/AzSpeech/Private/AzSpeech/Tasks/SpeechToTextAsync.cpp
@@ -10,21 +10,21 @@
 #include UE_INLINE_GENERATED_CPP_BY_NAME(SpeechToTextAsync)
 #endif
 
-USpeechToTextAsync* USpeechToTextAsync::SpeechToText_DefaultOptions(UObject* WorldContextObject, const FString& LanguageID, const FString& AudioInputDeviceID, const FName PhraseListGroup)
+USpeechToTextAsync* USpeechToTextAsync::SpeechToText_DefaultOptions(UObject* WorldContextObject, const FString& Locale, const FString& AudioInputDeviceID, const FName PhraseListGroup)
 {
-	return SpeechToText_CustomOptions(WorldContextObject, FAzSpeechSubscriptionOptions(), FAzSpeechRecognitionOptions(*LanguageID), AudioInputDeviceID, PhraseListGroup);
+	return SpeechToText_CustomOptions(WorldContextObject, FAzSpeechSubscriptionOptions(), FAzSpeechRecognitionOptions(*Locale), AudioInputDeviceID, PhraseListGroup);
 }
 
-USpeechToTextAsync* USpeechToTextAsync::SpeechToText_CustomOptions(UObject* WorldContextObject, const FAzSpeechSubscriptionOptions& SubscriptionOptions, const FAzSpeechRecognitionOptions& RecognitionOptions, const FString& AudioInputDeviceID, const FName PhraseListGroup)
+USpeechToTextAsync* USpeechToTextAsync::SpeechToText_CustomOptions(UObject* WorldContextObject, const FAzSpeechSubscriptionOptions SubscriptionOptions, const FAzSpeechRecognitionOptions RecognitionOptions, const FString& AudioInputDeviceID, const FName PhraseListGroup)
 {
 	USpeechToTextAsync* const NewAsyncTask = NewObject<USpeechToTextAsync>();
-	NewAsyncTask->WorldContextObject = WorldContextObject;
 	NewAsyncTask->SubscriptionOptions = SubscriptionOptions;
 	NewAsyncTask->RecognitionOptions = RecognitionOptions;
 	NewAsyncTask->AudioInputDeviceID = AudioInputDeviceID;
 	NewAsyncTask->PhraseListGroup = PhraseListGroup;
 	NewAsyncTask->bIsSSMLBased = false;
 	NewAsyncTask->TaskName = *FString(__func__);
+
 	NewAsyncTask->RegisterWithGameInstance(WorldContextObject);
 
 	return NewAsyncTask;
@@ -55,7 +55,7 @@ bool USpeechToTextAsync::StartAzureTaskWork()
 		return false;
 	}
 
-	if (AzSpeech::Internal::HasEmptyParam(GetRecognitionOptions().LanguageID))
+	if (AzSpeech::Internal::HasEmptyParam(GetRecognitionOptions().Locale))
 	{
 		return false;
 	}

--- a/Source/AzSpeech/Private/AzSpeech/Tasks/TextToAudioDataAsync.cpp
+++ b/Source/AzSpeech/Private/AzSpeech/Tasks/TextToAudioDataAsync.cpp
@@ -4,16 +4,30 @@
 
 #include "AzSpeech/Tasks/TextToAudioDataAsync.h"
 
+#if WITH_EDITOR
+#include <Editor.h>
+#endif
+
 #ifdef UE_INLINE_GENERATED_CPP_BY_NAME
 #include UE_INLINE_GENERATED_CPP_BY_NAME(TextToAudioDataAsync)
 #endif
 
-UTextToAudioDataAsync* UTextToAudioDataAsync::TextToAudioData_DefaultOptions(UObject* WorldContextObject, const FString& SynthesisText, const FString& VoiceName, const FString& LanguageID)
+#if WITH_EDITOR
+UTextToAudioDataAsync* UTextToAudioDataAsync::EditorTask(const FString& SynthesisText, const FString& Voice, const FString& Locale)
 {
-	return TextToAudioData_CustomOptions(WorldContextObject, FAzSpeechSubscriptionOptions(), FAzSpeechSynthesisOptions(*LanguageID, *VoiceName), SynthesisText);
+	UTextToAudioDataAsync* const NewAsyncTask = TextToAudioData_DefaultOptions(GEditor->GetEditorWorldContext().World(), SynthesisText, Voice, Locale);
+	NewAsyncTask->bIsEditorTask = true;
+
+	return NewAsyncTask;
+}
+#endif
+
+UTextToAudioDataAsync* UTextToAudioDataAsync::TextToAudioData_DefaultOptions(UObject* WorldContextObject, const FString& SynthesisText, const FString& Voice, const FString& Locale)
+{
+	return TextToAudioData_CustomOptions(WorldContextObject, FAzSpeechSubscriptionOptions(), FAzSpeechSynthesisOptions(*Locale, *Voice), SynthesisText);
 }
 
-UTextToAudioDataAsync* UTextToAudioDataAsync::TextToAudioData_CustomOptions(UObject* WorldContextObject, const FAzSpeechSubscriptionOptions& SubscriptionOptions, const FAzSpeechSynthesisOptions& SynthesisOptions, const FString& SynthesisText)
+UTextToAudioDataAsync* UTextToAudioDataAsync::TextToAudioData_CustomOptions(UObject* WorldContextObject, const FAzSpeechSubscriptionOptions SubscriptionOptions, const FAzSpeechSynthesisOptions SynthesisOptions, const FString& SynthesisText)
 {
 	UTextToAudioDataAsync* const NewAsyncTask = NewObject<UTextToAudioDataAsync>();
 	NewAsyncTask->WorldContextObject = WorldContextObject;
@@ -22,6 +36,7 @@ UTextToAudioDataAsync* UTextToAudioDataAsync::TextToAudioData_CustomOptions(UObj
 	NewAsyncTask->SynthesisOptions = SynthesisOptions;
 	NewAsyncTask->bIsSSMLBased = false;
 	NewAsyncTask->TaskName = *FString(__func__);
+
 	NewAsyncTask->RegisterWithGameInstance(WorldContextObject);
 
 	return NewAsyncTask;

--- a/Source/AzSpeech/Private/AzSpeech/Tasks/TextToSoundWaveAsync.cpp
+++ b/Source/AzSpeech/Private/AzSpeech/Tasks/TextToSoundWaveAsync.cpp
@@ -10,12 +10,12 @@
 #include UE_INLINE_GENERATED_CPP_BY_NAME(TextToSoundWaveAsync)
 #endif
 
-UTextToSoundWaveAsync* UTextToSoundWaveAsync::TextToSoundWave_DefaultOptions(UObject* WorldContextObject, const FString& SynthesisText, const FString& VoiceName, const FString& LanguageID)
+UTextToSoundWaveAsync* UTextToSoundWaveAsync::TextToSoundWave_DefaultOptions(UObject* WorldContextObject, const FString& SynthesisText, const FString& Voice, const FString& Locale)
 {
-	return TextToSoundWave_CustomOptions(WorldContextObject, FAzSpeechSubscriptionOptions(), FAzSpeechSynthesisOptions(*LanguageID, *VoiceName), SynthesisText);
+	return TextToSoundWave_CustomOptions(WorldContextObject, FAzSpeechSubscriptionOptions(), FAzSpeechSynthesisOptions(*Locale, *Voice), SynthesisText);
 }
 
-UTextToSoundWaveAsync* UTextToSoundWaveAsync::TextToSoundWave_CustomOptions(UObject* WorldContextObject, const FAzSpeechSubscriptionOptions& SubscriptionOptions, const FAzSpeechSynthesisOptions& SynthesisOptions, const FString& SynthesisText)
+UTextToSoundWaveAsync* UTextToSoundWaveAsync::TextToSoundWave_CustomOptions(UObject* WorldContextObject, const FAzSpeechSubscriptionOptions SubscriptionOptions, const FAzSpeechSynthesisOptions SynthesisOptions, const FString& SynthesisText)
 {
 	UTextToSoundWaveAsync* const NewAsyncTask = NewObject<UTextToSoundWaveAsync>();
 	NewAsyncTask->WorldContextObject = WorldContextObject;
@@ -24,6 +24,7 @@ UTextToSoundWaveAsync* UTextToSoundWaveAsync::TextToSoundWave_CustomOptions(UObj
 	NewAsyncTask->SynthesisOptions = SynthesisOptions;
 	NewAsyncTask->bIsSSMLBased = false;
 	NewAsyncTask->TaskName = *FString(__func__);
+
 	NewAsyncTask->RegisterWithGameInstance(WorldContextObject);
 
 	return NewAsyncTask;

--- a/Source/AzSpeech/Private/AzSpeech/Tasks/TextToSpeechAsync.cpp
+++ b/Source/AzSpeech/Private/AzSpeech/Tasks/TextToSpeechAsync.cpp
@@ -8,12 +8,12 @@
 #include UE_INLINE_GENERATED_CPP_BY_NAME(TextToSpeechAsync)
 #endif
 
-UTextToSpeechAsync* UTextToSpeechAsync::TextToSpeech_DefaultOptions(UObject* WorldContextObject, const FString& SynthesisText, const FString& VoiceName, const FString& LanguageID)
+UTextToSpeechAsync* UTextToSpeechAsync::TextToSpeech_DefaultOptions(UObject* WorldContextObject, const FString& SynthesisText, const FString& Voice, const FString& Locale)
 {
-	return TextToSpeech_CustomOptions(WorldContextObject, FAzSpeechSubscriptionOptions(), FAzSpeechSynthesisOptions(*LanguageID, *VoiceName), SynthesisText);
+	return TextToSpeech_CustomOptions(WorldContextObject, FAzSpeechSubscriptionOptions(), FAzSpeechSynthesisOptions(*Locale, *Voice), SynthesisText);
 }
 
-UTextToSpeechAsync* UTextToSpeechAsync::TextToSpeech_CustomOptions(UObject* WorldContextObject, const FAzSpeechSubscriptionOptions& SubscriptionOptions, const FAzSpeechSynthesisOptions& SynthesisOptions, const FString& SynthesisText)
+UTextToSpeechAsync* UTextToSpeechAsync::TextToSpeech_CustomOptions(UObject* WorldContextObject, const FAzSpeechSubscriptionOptions SubscriptionOptions, const FAzSpeechSynthesisOptions SynthesisOptions, const FString& SynthesisText)
 {
 	UTextToSpeechAsync* const NewAsyncTask = NewObject<UTextToSpeechAsync>();
 	NewAsyncTask->WorldContextObject = WorldContextObject;
@@ -22,6 +22,7 @@ UTextToSpeechAsync* UTextToSpeechAsync::TextToSpeech_CustomOptions(UObject* Worl
 	NewAsyncTask->SynthesisOptions = SynthesisOptions;
 	NewAsyncTask->bIsSSMLBased = false;
 	NewAsyncTask->TaskName = *FString(__func__);
+
 	NewAsyncTask->RegisterWithGameInstance(WorldContextObject);
 
 	return NewAsyncTask;

--- a/Source/AzSpeech/Private/AzSpeech/Tasks/TextToWavFileAsync.cpp
+++ b/Source/AzSpeech/Private/AzSpeech/Tasks/TextToWavFileAsync.cpp
@@ -8,15 +8,14 @@
 #include UE_INLINE_GENERATED_CPP_BY_NAME(TextToWavFileAsync)
 #endif
 
-UTextToWavFileAsync* UTextToWavFileAsync::TextToWavFile_DefaultOptions(UObject* WorldContextObject, const FString& SynthesisText, const FString& FilePath, const FString& FileName, const FString& VoiceName, const FString& LanguageID)
+UTextToWavFileAsync* UTextToWavFileAsync::TextToWavFile_DefaultOptions(UObject* WorldContextObject, const FString& SynthesisText, const FString& FilePath, const FString& FileName, const FString& Voice, const FString& Locale)
 {
-	return TextToWavFile_CustomOptions(WorldContextObject, FAzSpeechSubscriptionOptions(), FAzSpeechSynthesisOptions(*LanguageID, *VoiceName), SynthesisText, FilePath, FileName);
+	return TextToWavFile_CustomOptions(WorldContextObject, FAzSpeechSubscriptionOptions(), FAzSpeechSynthesisOptions(*Locale, *Voice), SynthesisText, FilePath, FileName);
 }
 
-UTextToWavFileAsync* UTextToWavFileAsync::TextToWavFile_CustomOptions(UObject* WorldContextObject, const FAzSpeechSubscriptionOptions& SubscriptionOptions, const FAzSpeechSynthesisOptions& SynthesisOptions, const FString& SynthesisText, const FString& FilePath, const FString& FileName)
+UTextToWavFileAsync* UTextToWavFileAsync::TextToWavFile_CustomOptions(UObject* WorldContextObject, const FAzSpeechSubscriptionOptions SubscriptionOptions, const FAzSpeechSynthesisOptions SynthesisOptions, const FString& SynthesisText, const FString& FilePath, const FString& FileName)
 {
 	UTextToWavFileAsync* const NewAsyncTask = NewObject<UTextToWavFileAsync>();
-	NewAsyncTask->WorldContextObject = WorldContextObject;
 	NewAsyncTask->SynthesisText = SynthesisText;
 	NewAsyncTask->SubscriptionOptions = SubscriptionOptions;
 	NewAsyncTask->SynthesisOptions = SynthesisOptions;
@@ -24,6 +23,7 @@ UTextToWavFileAsync* UTextToWavFileAsync::TextToWavFile_CustomOptions(UObject* W
 	NewAsyncTask->FileName = FileName;
 	NewAsyncTask->bIsSSMLBased = false;
 	NewAsyncTask->TaskName = *FString(__func__);
+
 	NewAsyncTask->RegisterWithGameInstance(WorldContextObject);
 
 	return NewAsyncTask;

--- a/Source/AzSpeech/Private/AzSpeech/Tasks/WavFileToTextAsync.cpp
+++ b/Source/AzSpeech/Private/AzSpeech/Tasks/WavFileToTextAsync.cpp
@@ -11,15 +11,14 @@
 #include UE_INLINE_GENERATED_CPP_BY_NAME(WavFileToTextAsync)
 #endif
 
-UWavFileToTextAsync* UWavFileToTextAsync::WavFileToText_DefaultOptions(UObject* WorldContextObject, const FString& FilePath, const FString& FileName, const FString& LanguageID, const FName PhraseListGroup)
+UWavFileToTextAsync* UWavFileToTextAsync::WavFileToText_DefaultOptions(UObject* WorldContextObject, const FString& FilePath, const FString& FileName, const FString& Locale, const FName PhraseListGroup)
 {
-	return WavFileToText_CustomOptions(WorldContextObject, FAzSpeechSubscriptionOptions(), FAzSpeechRecognitionOptions(*LanguageID), FilePath, FileName, PhraseListGroup);
+	return WavFileToText_CustomOptions(WorldContextObject, FAzSpeechSubscriptionOptions(), FAzSpeechRecognitionOptions(*Locale), FilePath, FileName, PhraseListGroup);
 }
 
-UWavFileToTextAsync* UWavFileToTextAsync::WavFileToText_CustomOptions(UObject* WorldContextObject, const FAzSpeechSubscriptionOptions& SubscriptionOptions, const FAzSpeechRecognitionOptions& RecognitionOptions, const FString& FilePath, const FString& FileName, const FName PhraseListGroup)
+UWavFileToTextAsync* UWavFileToTextAsync::WavFileToText_CustomOptions(UObject* WorldContextObject, const FAzSpeechSubscriptionOptions SubscriptionOptions, const FAzSpeechRecognitionOptions RecognitionOptions, const FString& FilePath, const FString& FileName, const FName PhraseListGroup)
 {
 	UWavFileToTextAsync* const NewAsyncTask = NewObject<UWavFileToTextAsync>();
-	NewAsyncTask->WorldContextObject = WorldContextObject;
 	NewAsyncTask->SubscriptionOptions = SubscriptionOptions;
 	NewAsyncTask->RecognitionOptions = RecognitionOptions;
 	NewAsyncTask->FilePath = FilePath;
@@ -27,6 +26,7 @@ UWavFileToTextAsync* UWavFileToTextAsync::WavFileToText_CustomOptions(UObject* W
 	NewAsyncTask->PhraseListGroup = PhraseListGroup;
 	NewAsyncTask->bIsSSMLBased = false;
 	NewAsyncTask->TaskName = *FString(__func__);
+
 	NewAsyncTask->RegisterWithGameInstance(WorldContextObject);
 
 	return NewAsyncTask;
@@ -52,7 +52,7 @@ bool UWavFileToTextAsync::StartAzureTaskWork()
 		return false;
 	}
 	
-	if (AzSpeech::Internal::HasEmptyParam(FilePath, FileName, GetRecognitionOptions().LanguageID))
+	if (AzSpeech::Internal::HasEmptyParam(FilePath, FileName, GetRecognitionOptions().Locale))
 	{
 		return false;
 	}

--- a/Source/AzSpeech/Public/AzSpeech/Structures/AzSpeechSettingsOptions.h
+++ b/Source/AzSpeech/Public/AzSpeech/Structures/AzSpeechSettingsOptions.h
@@ -87,10 +87,10 @@ struct AZSPEECH_API FAzSpeechRecognitionOptions
 
 public:
 	FAzSpeechRecognitionOptions();
-	FAzSpeechRecognitionOptions(const FName& LanguageID);
+	FAzSpeechRecognitionOptions(const FName& Locale);
 
-	UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "Tasks", Meta = (DisplayName = "Language ID"))
-	FName LanguageID;
+	UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "Tasks", Meta = (DisplayName = "Locale"))
+	FName Locale;
 
 	UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "Tasks", Meta = (DisplayName = "Use Language Identification"))
 	bool bUseLanguageIdentification;
@@ -133,14 +133,14 @@ struct AZSPEECH_API FAzSpeechSynthesisOptions
 
 public:
 	FAzSpeechSynthesisOptions();
-	FAzSpeechSynthesisOptions(const FName& LanguageID);
-	FAzSpeechSynthesisOptions(const FName& LanguageID, const FName& VoiceName);
+	FAzSpeechSynthesisOptions(const FName& Locale);
+	FAzSpeechSynthesisOptions(const FName& Locale, const FName& Voice);
 
-	UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "Tasks", Meta = (DisplayName = "Language ID"))
-	FName LanguageID;
+	UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "Tasks", Meta = (DisplayName = "Locale"))
+	FName Locale;
 
-	UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "Tasks", Meta = (DisplayName = "Voice Name"))
-	FName VoiceName;
+	UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "Tasks", Meta = (DisplayName = "Voice"))
+	FName Voice;
 
 	/* If enabled, tasks will generate Viseme data */
 	UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "Tasks", Meta = (DisplayName = "Enable Viseme"))

--- a/Source/AzSpeech/Public/AzSpeech/Tasks/Bases/AzSpeechAudioDataSynthesisBase.h
+++ b/Source/AzSpeech/Public/AzSpeech/Tasks/Bases/AzSpeechAudioDataSynthesisBase.h
@@ -18,4 +18,6 @@ class AZSPEECH_API UAzSpeechAudioDataSynthesisBase : public UAzSpeechSynthesizer
 	
 protected:
 	virtual bool StartAzureTaskWork() override;
+
+	const UObject* WorldContextObject;
 };

--- a/Source/AzSpeech/Public/AzSpeech/Tasks/Bases/AzSpeechTaskBase.h
+++ b/Source/AzSpeech/Public/AzSpeech/Tasks/Bases/AzSpeechTaskBase.h
@@ -49,7 +49,6 @@ protected:
 
 	FAzSpeechSubscriptionOptions SubscriptionOptions;
 
-	const UObject* WorldContextObject;
 	bool bIsSSMLBased = false;
 
 	virtual bool StartAzureTaskWork();
@@ -58,9 +57,10 @@ protected:
 	mutable FCriticalSection Mutex;
 
 #if WITH_EDITOR
-	virtual void PrePIEEnded(bool bIsSimulating);
-
+	bool bIsEditorTask = false;
 	bool bEndingPIE = false;
+
+	virtual void PrePIEEnded(bool bIsSimulating);
 #endif
 
 	template <typename ReturnTy, typename ResultType>

--- a/Source/AzSpeech/Public/AzSpeech/Tasks/GetAvailableVoicesAsync.h
+++ b/Source/AzSpeech/Public/AzSpeech/Tasks/GetAvailableVoicesAsync.h
@@ -36,7 +36,6 @@ public:
 	virtual void SetReadyToDestroy() override;
 
 protected:
-	const UObject* WorldContextObject;
 	FName TaskName;
 	FString Locale;
 

--- a/Source/AzSpeech/Public/AzSpeech/Tasks/RecognitionMapCheckAsync.h
+++ b/Source/AzSpeech/Public/AzSpeech/Tasks/RecognitionMapCheckAsync.h
@@ -38,7 +38,6 @@ public:
 	virtual void SetReadyToDestroy() override;
 
 protected:
-	const UObject* WorldContextObject;
 	FName TaskName;
 	FName GroupName;
 	FString InputString;

--- a/Source/AzSpeech/Public/AzSpeech/Tasks/SSMLToAudioDataAsync.h
+++ b/Source/AzSpeech/Public/AzSpeech/Tasks/SSMLToAudioDataAsync.h
@@ -21,13 +21,17 @@ public:
 	UPROPERTY(BlueprintAssignable, Category = "AzSpeech")
 	FAudioDataSynthesisDelegate SynthesisCompleted;
 
+#if WITH_EDITOR
+	static USSMLToAudioDataAsync* EditorTask(const FString& SynthesisSSML);
+#endif
+
 	/* Creates a SSML-To-AudioData task that will convert your SSML file to a audio data */
 	UFUNCTION(BlueprintCallable, Category = "AzSpeech | Default", meta = (BlueprintInternalUseOnly = "true", WorldContext = "WorldContextObject", DisplayName = "SSML To Audio Data with Default Options"))
 	static USSMLToAudioDataAsync* SSMLToAudioData_DefaultOptions(UObject* WorldContextObject, const FString& SynthesisSSML);
 
 	/* Creates a SSML-To-AudioData task that will convert your SSML file to a audio data */
 	UFUNCTION(BlueprintCallable, Category = "AzSpeech | Custom", meta = (BlueprintInternalUseOnly = "true", WorldContext = "WorldContextObject", DisplayName = "SSML To Audio Data with Custom Options"))
-	static USSMLToAudioDataAsync* SSMLToAudioData_CustomOptions(UObject* WorldContextObject, const FAzSpeechSubscriptionOptions& SubscriptionOptions, const FAzSpeechSynthesisOptions& SynthesisOptions, const FString& SynthesisSSML);
+	static USSMLToAudioDataAsync* SSMLToAudioData_CustomOptions(UObject* WorldContextObject, const FAzSpeechSubscriptionOptions SubscriptionOptions, const FAzSpeechSynthesisOptions SynthesisOptions, const FString& SynthesisSSML);
 	
 protected:
 	virtual void BroadcastFinalResult() override;

--- a/Source/AzSpeech/Public/AzSpeech/Tasks/SSMLToSoundWaveAsync.h
+++ b/Source/AzSpeech/Public/AzSpeech/Tasks/SSMLToSoundWaveAsync.h
@@ -27,7 +27,7 @@ public:
 
 	/* Creates a SSML-To-SoundWave task that will convert your SSML file to a USoundWave */
 	UFUNCTION(BlueprintCallable, Category = "AzSpeech | Custom", meta = (BlueprintInternalUseOnly = "true", WorldContext = "WorldContextObject", DisplayName = "SSML To Sound Wave with Custom Options"))
-	static USSMLToSoundWaveAsync* SSMLToSoundWave_CustomOptions(UObject* WorldContextObject, const FAzSpeechSubscriptionOptions& SubscriptionOptions, const FAzSpeechSynthesisOptions& SynthesisOptions, const FString& SynthesisSSML);
+	static USSMLToSoundWaveAsync* SSMLToSoundWave_CustomOptions(UObject* WorldContextObject, const FAzSpeechSubscriptionOptions SubscriptionOptions, const FAzSpeechSynthesisOptions SynthesisOptions, const FString& SynthesisSSML);
 
 protected:
 	virtual void BroadcastFinalResult() override;

--- a/Source/AzSpeech/Public/AzSpeech/Tasks/SSMLToSpeechAsync.h
+++ b/Source/AzSpeech/Public/AzSpeech/Tasks/SSMLToSpeechAsync.h
@@ -23,5 +23,5 @@ public:
 
 	/* Creates a SSML-To-Speech task that will convert your SSML file to speech */
 	UFUNCTION(BlueprintCallable, Category = "AzSpeech | Custom", meta = (BlueprintInternalUseOnly = "true", WorldContext = "WorldContextObject", DisplayName = "SSML To Speech with Custom Options"))
-	static USSMLToSpeechAsync* SSMLToSpeech_CustomOptions(UObject* WorldContextObject, const FAzSpeechSubscriptionOptions& SubscriptionOptions, const FAzSpeechSynthesisOptions& SynthesisOptions, const FString& SynthesisSSML);
+	static USSMLToSpeechAsync* SSMLToSpeech_CustomOptions(UObject* WorldContextObject, const FAzSpeechSubscriptionOptions SubscriptionOptions, const FAzSpeechSynthesisOptions SynthesisOptions, const FString& SynthesisSSML);
 };

--- a/Source/AzSpeech/Public/AzSpeech/Tasks/SSMLToWavFileAsync.h
+++ b/Source/AzSpeech/Public/AzSpeech/Tasks/SSMLToWavFileAsync.h
@@ -23,5 +23,5 @@ public:
 
 	/* Creates a Text-To-WavFile task that will convert your string to a .wav audio file */
 	UFUNCTION(BlueprintCallable, Category = "AzSpeech | Custom", meta = (BlueprintInternalUseOnly = "true", WorldContext = "WorldContextObject", DisplayName = "SSML To .wav File with Custom Options"))
-	static USSMLToWavFileAsync* SSMLToWavFile_CustomOptions(UObject* WorldContextObject, const FAzSpeechSubscriptionOptions& SubscriptionOptions, const FAzSpeechSynthesisOptions& SynthesisOptions, const FString& SynthesisSSML, const FString& FilePath, const FString& FileName);
+	static USSMLToWavFileAsync* SSMLToWavFile_CustomOptions(UObject* WorldContextObject, const FAzSpeechSubscriptionOptions SubscriptionOptions, const FAzSpeechSynthesisOptions SynthesisOptions, const FString& SynthesisSSML, const FString& FilePath, const FString& FileName);
 };

--- a/Source/AzSpeech/Public/AzSpeech/Tasks/SpeechToTextAsync.h
+++ b/Source/AzSpeech/Public/AzSpeech/Tasks/SpeechToTextAsync.h
@@ -19,11 +19,11 @@ class AZSPEECH_API USpeechToTextAsync : public UAzSpeechRecognizerTaskBase
 public:
 	/* Creates a Speech-To-Text task that will convert your speech to string */
 	UFUNCTION(BlueprintCallable, Category = "AzSpeech | Default", meta = (BlueprintInternalUseOnly = "true", WorldContext = "WorldContextObject", DisplayName = "Speech to Text with Default Options"))
-	static USpeechToTextAsync* SpeechToText_DefaultOptions(UObject* WorldContextObject, const FString& LanguageID = "Default", const FString& AudioInputDeviceID = "Default", const FName PhraseListGroup = NAME_None);
+	static USpeechToTextAsync* SpeechToText_DefaultOptions(UObject* WorldContextObject, const FString& Locale = "Default", const FString& AudioInputDeviceID = "Default", const FName PhraseListGroup = NAME_None);
 
 	/* Creates a Speech-To-Text task that will convert your speech to string */
 	UFUNCTION(BlueprintCallable, Category = "AzSpeech | Custom", meta = (BlueprintInternalUseOnly = "true", WorldContext = "WorldContextObject", DisplayName = "Speech to Text with Custom Options"))
-	static USpeechToTextAsync* SpeechToText_CustomOptions(UObject* WorldContextObject, const FAzSpeechSubscriptionOptions& SubscriptionOptions, const FAzSpeechRecognitionOptions& RecognitionOptions, const FString& AudioInputDeviceID = "Default", const FName PhraseListGroup = NAME_None);
+	static USpeechToTextAsync* SpeechToText_CustomOptions(UObject* WorldContextObject, const FAzSpeechSubscriptionOptions SubscriptionOptions, const FAzSpeechRecognitionOptions RecognitionOptions, const FString& AudioInputDeviceID = "Default", const FName PhraseListGroup = NAME_None);
 
 	virtual void Activate() override;
 	

--- a/Source/AzSpeech/Public/AzSpeech/Tasks/TextToAudioDataAsync.h
+++ b/Source/AzSpeech/Public/AzSpeech/Tasks/TextToAudioDataAsync.h
@@ -21,13 +21,17 @@ public:
 	UPROPERTY(BlueprintAssignable, Category = "AzSpeech")
 	FAudioDataSynthesisDelegate SynthesisCompleted;
 
+#if WITH_EDITOR
+	static UTextToAudioDataAsync* EditorTask(const FString& SynthesisText, const FString& Voice, const FString& Locale);
+#endif
+
 	/* Creates a Text-To-AudioData task that will convert your text to a audio data stream */
 	UFUNCTION(BlueprintCallable, Category = "AzSpeech | Default", meta = (BlueprintInternalUseOnly = "true", WorldContext = "WorldContextObject", DisplayName = "Text To Audio Data with Default Options"))
-	static UTextToAudioDataAsync* TextToAudioData_DefaultOptions(UObject* WorldContextObject, const FString& SynthesisText, const FString& VoiceName = "Default", const FString& LanguageID = "Default");
+	static UTextToAudioDataAsync* TextToAudioData_DefaultOptions(UObject* WorldContextObject, const FString& SynthesisText, const FString& Voice = "Default", const FString& Locale = "Default");
 
 	/* Creates a Text-To-AudioData task that will convert your text to a audio data stream */
 	UFUNCTION(BlueprintCallable, Category = "AzSpeech | Custom", meta = (BlueprintInternalUseOnly = "true", WorldContext = "WorldContextObject", DisplayName = "Text To Audio Data with Custom Options"))
-	static UTextToAudioDataAsync* TextToAudioData_CustomOptions(UObject* WorldContextObject, const FAzSpeechSubscriptionOptions& SubscriptionOptions, const FAzSpeechSynthesisOptions& SynthesisOptions, const FString& SynthesisText);
+	static UTextToAudioDataAsync* TextToAudioData_CustomOptions(UObject* WorldContextObject, const FAzSpeechSubscriptionOptions SubscriptionOptions, const FAzSpeechSynthesisOptions SynthesisOptions, const FString& SynthesisText);
 
 protected:
 	virtual void BroadcastFinalResult() override;

--- a/Source/AzSpeech/Public/AzSpeech/Tasks/TextToSoundWaveAsync.h
+++ b/Source/AzSpeech/Public/AzSpeech/Tasks/TextToSoundWaveAsync.h
@@ -23,11 +23,11 @@ public:
 
 	/* Creates a Text-To-SoundWave task that will convert your text to a USoundWave */
 	UFUNCTION(BlueprintCallable, Category = "AzSpeech | Default", meta = (BlueprintInternalUseOnly = "true", WorldContext = "WorldContextObject", DisplayName = "Text To Sound Wave with Default Options"))
-	static UTextToSoundWaveAsync* TextToSoundWave_DefaultOptions(UObject* WorldContextObject, const FString& SynthesisText, const FString& VoiceName = "Default", const FString& LanguageID = "Default");
+	static UTextToSoundWaveAsync* TextToSoundWave_DefaultOptions(UObject* WorldContextObject, const FString& SynthesisText, const FString& Voice = "Default", const FString& Locale = "Default");
 
 	/* Creates a Text-To-SoundWave task that will convert your text to a USoundWave */
 	UFUNCTION(BlueprintCallable, Category = "AzSpeech | Custom", meta = (BlueprintInternalUseOnly = "true", WorldContext = "WorldContextObject", DisplayName = "Text To Sound Wave with Custom Options"))
-	static UTextToSoundWaveAsync* TextToSoundWave_CustomOptions(UObject* WorldContextObject, const FAzSpeechSubscriptionOptions& SubscriptionOptions, const FAzSpeechSynthesisOptions& SynthesisOptions, const FString& SynthesisText);
+	static UTextToSoundWaveAsync* TextToSoundWave_CustomOptions(UObject* WorldContextObject, const FAzSpeechSubscriptionOptions SubscriptionOptions, const FAzSpeechSynthesisOptions SynthesisOptions, const FString& SynthesisText);
 
 protected:
 	virtual void BroadcastFinalResult() override;

--- a/Source/AzSpeech/Public/AzSpeech/Tasks/TextToSpeechAsync.h
+++ b/Source/AzSpeech/Public/AzSpeech/Tasks/TextToSpeechAsync.h
@@ -19,9 +19,9 @@ class AZSPEECH_API UTextToSpeechAsync : public UAzSpeechSpeechSynthesisBase
 public:
 	/* Creates a Text-To-Speech task that will convert your text to speech */
 	UFUNCTION(BlueprintCallable, Category = "AzSpeech | Default", meta = (BlueprintInternalUseOnly = "true", WorldContext = "WorldContextObject", DisplayName = "Text To Speech with Default Options"))
-	static UTextToSpeechAsync* TextToSpeech_DefaultOptions(UObject* WorldContextObject, const FString& SynthesisText, const FString& VoiceName = "Default", const FString& LanguageID = "Default");
+	static UTextToSpeechAsync* TextToSpeech_DefaultOptions(UObject* WorldContextObject, const FString& SynthesisText, const FString& Voice = "Default", const FString& Locale = "Default");
 
 	/* Creates a Text-To-Speech task that will convert your text to speech */
 	UFUNCTION(BlueprintCallable, Category = "AzSpeech | Custom", meta = (BlueprintInternalUseOnly = "true", WorldContext = "WorldContextObject", DisplayName = "Text To Speech with Custom Options"))
-	static UTextToSpeechAsync* TextToSpeech_CustomOptions(UObject* WorldContextObject, const FAzSpeechSubscriptionOptions& SubscriptionOptions, const FAzSpeechSynthesisOptions& SynthesisOptions, const FString& SynthesisText);
+	static UTextToSpeechAsync* TextToSpeech_CustomOptions(UObject* WorldContextObject, const FAzSpeechSubscriptionOptions SubscriptionOptions, const FAzSpeechSynthesisOptions SynthesisOptions, const FString& SynthesisText);
 };

--- a/Source/AzSpeech/Public/AzSpeech/Tasks/TextToWavFileAsync.h
+++ b/Source/AzSpeech/Public/AzSpeech/Tasks/TextToWavFileAsync.h
@@ -19,9 +19,9 @@ class AZSPEECH_API UTextToWavFileAsync : public UAzSpeechWavFileSynthesisBase
 public:
 	/* Creates a Text-To-WavFile task that will convert your string to a .wav audio file */
 	UFUNCTION(BlueprintCallable, Category = "AzSpeech | Default", meta = (BlueprintInternalUseOnly = "true", WorldContext = "WorldContextObject", DisplayName = "Text To .wav File with Default Options"))
-	static UTextToWavFileAsync* TextToWavFile_DefaultOptions(UObject* WorldContextObject, const FString& SynthesisText, const FString& FilePath, const FString& FileName, const FString& VoiceName = "Default", const FString& LanguageID = "Default");
+	static UTextToWavFileAsync* TextToWavFile_DefaultOptions(UObject* WorldContextObject, const FString& SynthesisText, const FString& FilePath, const FString& FileName, const FString& Voice = "Default", const FString& Locale = "Default");
 
 	/* Creates a Text-To-WavFile task that will convert your string to a .wav audio file */
 	UFUNCTION(BlueprintCallable, Category = "AzSpeech | Custom", meta = (BlueprintInternalUseOnly = "true", WorldContext = "WorldContextObject", DisplayName = "Text To .wav File with Custom Options"))
-	static UTextToWavFileAsync* TextToWavFile_CustomOptions(UObject* WorldContextObject, const FAzSpeechSubscriptionOptions& SubscriptionOptions, const FAzSpeechSynthesisOptions& SynthesisOptions, const FString& SynthesisText, const FString& FilePath, const FString& FileName);
+	static UTextToWavFileAsync* TextToWavFile_CustomOptions(UObject* WorldContextObject, const FAzSpeechSubscriptionOptions SubscriptionOptions, const FAzSpeechSynthesisOptions SynthesisOptions, const FString& SynthesisText, const FString& FilePath, const FString& FileName);
 };

--- a/Source/AzSpeech/Public/AzSpeech/Tasks/WavFileToTextAsync.h
+++ b/Source/AzSpeech/Public/AzSpeech/Tasks/WavFileToTextAsync.h
@@ -19,11 +19,11 @@ class AZSPEECH_API UWavFileToTextAsync : public UAzSpeechRecognizerTaskBase
 public:
 	/* Creates a WavFile-To-Text task that will convert your Wav file to string */
 	UFUNCTION(BlueprintCallable, Category = "AzSpeech | Default", meta = (BlueprintInternalUseOnly = "true", WorldContext = "WorldContextObject", DisplayName = ".wav File To Text with Default Options"))
-	static UWavFileToTextAsync* WavFileToText_DefaultOptions(UObject* WorldContextObject, const FString& FilePath, const FString& FileName, const FString& LanguageID = "Default", const FName PhraseListGroup = NAME_None);
+	static UWavFileToTextAsync* WavFileToText_DefaultOptions(UObject* WorldContextObject, const FString& FilePath, const FString& FileName, const FString& Locale = "Default", const FName PhraseListGroup = NAME_None);
 
 	/* Creates a WavFile-To-Text task that will convert your Wav file to string */
 	UFUNCTION(BlueprintCallable, Category = "AzSpeech | Custom", meta = (BlueprintInternalUseOnly = "true", WorldContext = "WorldContextObject", DisplayName = ".wav File To Text with Custom Options"))
-	static UWavFileToTextAsync* WavFileToText_CustomOptions(UObject* WorldContextObject, const FAzSpeechSubscriptionOptions& SubscriptionOptions, const FAzSpeechRecognitionOptions& RecognitionOptions, const FString& FilePath, const FString& FileName, const FName PhraseListGroup = NAME_None);
+	static UWavFileToTextAsync* WavFileToText_CustomOptions(UObject* WorldContextObject, const FAzSpeechSubscriptionOptions SubscriptionOptions, const FAzSpeechRecognitionOptions RecognitionOptions, const FString& FilePath, const FString& FileName, const FName PhraseListGroup = NAME_None);
 
 	virtual void Activate() override;
 

--- a/Source/AzSpeechEditor/Private/SAzSpeechAudioGenerator.cpp
+++ b/Source/AzSpeechEditor/Private/SAzSpeechAudioGenerator.cpp
@@ -43,6 +43,8 @@ void UAzSpeechPropertiesGetter::TaskFail()
 
 void UAzSpeechPropertiesGetter::Destroy()
 {
+	ClearFlags(RF_Standalone);
+
 #if ENGINE_MAJOR_VERSION >= 5
 	MarkAsGarbage();
 #else
@@ -239,6 +241,8 @@ void SAzSpeechAudioGenerator::Construct([[maybe_unused]] const FArguments&)
 void SAzSpeechAudioGenerator::UpdateAvailableVoices()
 {
 	UAzSpeechPropertiesGetter* const InternalGetter = NewObject<UAzSpeechPropertiesGetter>();
+	InternalGetter->SetFlags(RF_Standalone);
+
 	InternalGetter->OnAvailableVoicesUpdated.BindLambda(
 		[this](TArray<FString> Voices)
 		{
@@ -260,6 +264,8 @@ FReply SAzSpeechAudioGenerator::HandleGenerateAudioButtonClicked()
 	}
 
 	UAzSpeechPropertiesGetter* const InternalGetter = NewObject<UAzSpeechPropertiesGetter>();
+	InternalGetter->SetFlags(RF_Standalone);
+
 	InternalGetter->OnAudioDataGenerated.BindLambda(
 		[this](TArray<uint8> AudioData)
 		{
@@ -273,12 +279,12 @@ FReply SAzSpeechAudioGenerator::HandleGenerateAudioButtonClicked()
 	UAzSpeechAudioDataSynthesisBase* Task = nullptr;
 	if (bIsSSMLBased)
 	{
-		Task = USSMLToAudioDataAsync::SSMLToAudioData_DefaultOptions(GEditor->GetEditorWorldContext().World(), SynthesisText.ToString());
+		Task = USSMLToAudioDataAsync::EditorTask(SynthesisText.ToString());
 		Cast<USSMLToAudioDataAsync>(Task)->SynthesisCompleted.AddDynamic(InternalGetter, &UAzSpeechPropertiesGetter::SynthesisCompleted);
 	}
 	else
 	{
-		Task = UTextToAudioDataAsync::TextToAudioData_DefaultOptions(GEditor->GetEditorWorldContext().World(), SynthesisText.ToString(), Voice, Locale);
+		Task = UTextToAudioDataAsync::EditorTask(SynthesisText.ToString(), Voice, Locale);
 		Cast<UTextToAudioDataAsync>(Task)->SynthesisCompleted.AddDynamic(InternalGetter, &UAzSpeechPropertiesGetter::SynthesisCompleted);
 	}
 


### PR DESCRIPTION
## Changes
* Adjust Audio Generator Tool internal notifications
* Add new C++ functions to call editor tasks
* Add new property to identify editor tasks and apply or not flags / End PIE binding
* Set editor tasks & editor internal getter object to receive the RF_Standalone flag to avoid being destroyed when editor context changes
* Add missing scope in recognition final broadcast caller function: Fix recognition completed not being called

## Notes
* Some changes fix the bug related to the editor tasks being canceled when these situations occur: Save, Play PIE or End PIE.