### PR TITLE
Fix bug: Some tasks were not being set as ready to destroy

### DIFF
--- a/AzSpeech.uplugin
+++ b/AzSpeech.uplugin
@@ -1,7 +1,7 @@
 {
 	"FileVersion": 3,
-	"Version": 29,
-	"VersionName": "1.6.12",
+	"Version": 30,
+	"VersionName": "1.6.13",
 	"FriendlyName": "AzSpeech - Voice and Text",
 	"Description": "Integrates Azure Speech Cognitive Services into the Engine by adding functions to perform recognition and synthesis via asynchronous tasks.",
 	"Category": "Game Features",

--- a/Source/AzSpeech/Private/AzSpeech/Runnables/Bases/AzSpeechRunnableBase.cpp
+++ b/Source/AzSpeech/Private/AzSpeech/Runnables/Bases/AzSpeechRunnableBase.cpp
@@ -28,6 +28,21 @@ FAzSpeechRunnableBase::FAzSpeechRunnableBase(UAzSpeechTaskBase* const InOwningTa
 {
 }
 
+FAzSpeechRunnableBase::~FAzSpeechRunnableBase()
+{
+    if (IsRunning())
+    {
+        Stop();
+    }
+
+    if (Thread.IsValid())
+    {
+        Thread->Kill(true);
+    }
+
+    UE_LOG(LogAzSpeech_Internal, Display, TEXT("Thread: %s; Function: %s; Message: Destructing runnable thread"), *GetThreadName(), *FString(__func__));
+}
+
 void FAzSpeechRunnableBase::StartAzSpeechRunnableTask()
 {
     Thread.Reset(FRunnableThread::Create(this, *FString::Printf(TEXT("AzSpeech_%s_%d"), *GetOwningTask()->GetTaskName().ToString(), GetOwningTask()->GetUniqueID()), 0u, GetCPUThreadPriority()));
@@ -37,6 +52,11 @@ void FAzSpeechRunnableBase::StopAzSpeechRunnableTask()
 {
     UE_LOG(LogAzSpeech_Internal, Display, TEXT("Thread: %s; Function: %s; Message: Setting runnable work as pending stop"), *GetThreadName(), *FString(__func__));
     bStopTask = true;
+}
+
+bool FAzSpeechRunnableBase::IsRunning() const
+{
+    return !bStopTask;
 }
 
 bool FAzSpeechRunnableBase::IsPendingStop() const

--- a/Source/AzSpeech/Private/AzSpeech/Tasks/Bases/AzSpeechTaskBase.cpp
+++ b/Source/AzSpeech/Private/AzSpeech/Tasks/Bases/AzSpeechTaskBase.cpp
@@ -80,8 +80,8 @@ void UAzSpeechTaskBase::StopAzSpeechTask()
 
     UE_LOG(LogAzSpeech, Display, TEXT("Task: %s (%d); Function: %s; Message: Stopping task"), *TaskName.ToString(), GetUniqueID(), *FString(__func__));
     bIsTaskActive = false;
-
-    if (RunnableTask)
+    
+    if (RunnableTask.IsValid())
     {
         RunnableTask->StopAzSpeechRunnableTask();
     }
@@ -148,9 +148,10 @@ void UAzSpeechTaskBase::SetReadyToDestroy()
     }
 #endif
 
-    if (RunnableTask)
+    if (RunnableTask.IsValid())
     {
         RunnableTask->StopAzSpeechRunnableTask();
+        RunnableTask.Reset();
     }
 
     Super::SetReadyToDestroy();

--- a/Source/AzSpeech/Private/AzSpeech/Tasks/Recognition/Bases/AzSpeechRecognizerTaskBase.cpp
+++ b/Source/AzSpeech/Private/AzSpeech/Tasks/Recognition/Bases/AzSpeechRecognizerTaskBase.cpp
@@ -62,7 +62,7 @@ const int32 UAzSpeechRecognizerTaskBase::GetRecognitionLatency() const
 
 void UAzSpeechRecognizerTaskBase::StartRecognitionWork(const std::shared_ptr<MicrosoftSpeech::Audio::AudioConfig> InAudioConfig)
 {
-    RunnableTask = MakeShared<FAzSpeechRecognitionRunnable>(this, InAudioConfig);
+    RunnableTask = MakeUnique<FAzSpeechRecognitionRunnable>(this, InAudioConfig);
 
     if (!RunnableTask)
     {
@@ -88,6 +88,7 @@ void UAzSpeechRecognizerTaskBase::BroadcastFinalResult()
         [this]
         {
             RecognitionCompleted.Broadcast(GetRecognizedString());
+            SetReadyToDestroy();
         }
     );
 }

--- a/Source/AzSpeech/Private/AzSpeech/Tasks/Recognition/KeywordRecognitionAsync.cpp
+++ b/Source/AzSpeech/Private/AzSpeech/Tasks/Recognition/KeywordRecognitionAsync.cpp
@@ -98,7 +98,7 @@ void UKeywordRecognitionAsync::StartRecognitionWork(const std::shared_ptr<Micros
         return;
     }
 
-    RunnableTask = MakeShared<FAzSpeechKeywordRecognitionRunnable>(this, InAudioConfig, MicrosoftSpeech::KeywordRecognitionModel::FromFile(TCHAR_TO_UTF8(*ModelPath)));
+    RunnableTask = MakeUnique<FAzSpeechKeywordRecognitionRunnable>(this, InAudioConfig, MicrosoftSpeech::KeywordRecognitionModel::FromFile(TCHAR_TO_UTF8(*ModelPath)));
     if (!RunnableTask)
     {
         SetReadyToDestroy();

--- a/Source/AzSpeech/Private/AzSpeech/Tasks/Synthesis/Bases/AzSpeechSynthesizerTaskBase.cpp
+++ b/Source/AzSpeech/Private/AzSpeech/Tasks/Synthesis/Bases/AzSpeechSynthesizerTaskBase.cpp
@@ -145,7 +145,7 @@ const int32 UAzSpeechSynthesizerTaskBase::GetServiceLatency() const
 
 void UAzSpeechSynthesizerTaskBase::StartSynthesisWork(const std::shared_ptr<MicrosoftSpeech::Audio::AudioConfig> InAudioConfig)
 {
-    RunnableTask = MakeShared<FAzSpeechSynthesisRunnable>(this, InAudioConfig);
+    RunnableTask = MakeUnique<FAzSpeechSynthesisRunnable>(this, InAudioConfig);
 
     if (!RunnableTask)
     {

--- a/Source/AzSpeech/Private/AzSpeech/Tasks/Synthesis/Bases/AzSpeechWavFileSynthesisBase.cpp
+++ b/Source/AzSpeech/Private/AzSpeech/Tasks/Synthesis/Bases/AzSpeechWavFileSynthesisBase.cpp
@@ -69,8 +69,9 @@ void UAzSpeechWavFileSynthesisBase::BroadcastFinalResult()
     }
 
     Super::BroadcastFinalResult();
-
     SynthesisCompleted.Broadcast(IsLastResultValid() && UAzSpeechHelper::IsAudioDataValid(GetAudioData()));
+
+    SetReadyToDestroy();
 }
 
 bool UAzSpeechWavFileSynthesisBase::StartAzureTaskWork()

--- a/Source/AzSpeech/Private/AzSpeech/Tasks/Synthesis/SSMLToAudioDataAsync.cpp
+++ b/Source/AzSpeech/Private/AzSpeech/Tasks/Synthesis/SSMLToAudioDataAsync.cpp
@@ -52,6 +52,7 @@ void USSMLToAudioDataAsync::BroadcastFinalResult()
     }
 
     Super::BroadcastFinalResult();
-
     SynthesisCompleted.Broadcast(GetAudioData());
+
+    SetReadyToDestroy();
 }

--- a/Source/AzSpeech/Private/AzSpeech/Tasks/Synthesis/SSMLToSoundWaveAsync.cpp
+++ b/Source/AzSpeech/Private/AzSpeech/Tasks/Synthesis/SSMLToSoundWaveAsync.cpp
@@ -40,7 +40,7 @@ void USSMLToSoundWaveAsync::BroadcastFinalResult()
     }
 
     Super::BroadcastFinalResult();
+    SynthesisCompleted.Broadcast(UAzSpeechHelper::ConvertAudioDataToSoundWave(GetAudioData()));
 
-    const TArray<uint8> LastBuffer = GetAudioData();
-    SynthesisCompleted.Broadcast(UAzSpeechHelper::ConvertAudioDataToSoundWave(LastBuffer));
+    SetReadyToDestroy();
 }

--- a/Source/AzSpeech/Private/AzSpeech/Tasks/Synthesis/TextToAudioDataAsync.cpp
+++ b/Source/AzSpeech/Private/AzSpeech/Tasks/Synthesis/TextToAudioDataAsync.cpp
@@ -52,6 +52,7 @@ void UTextToAudioDataAsync::BroadcastFinalResult()
     }
 
     Super::BroadcastFinalResult();
-
     SynthesisCompleted.Broadcast(GetAudioData());
+
+    SetReadyToDestroy();
 }

--- a/Source/AzSpeech/Private/AzSpeech/Tasks/Synthesis/TextToSoundWaveAsync.cpp
+++ b/Source/AzSpeech/Private/AzSpeech/Tasks/Synthesis/TextToSoundWaveAsync.cpp
@@ -40,7 +40,7 @@ void UTextToSoundWaveAsync::BroadcastFinalResult()
     }
 
     Super::BroadcastFinalResult();
+    SynthesisCompleted.Broadcast(UAzSpeechHelper::ConvertAudioDataToSoundWave(GetAudioData()));
 
-    const TArray<uint8> LastBuffer = GetAudioData();
-    SynthesisCompleted.Broadcast(UAzSpeechHelper::ConvertAudioDataToSoundWave(LastBuffer));
+    SetReadyToDestroy();
 }

--- a/Source/AzSpeech/Public/AzSpeech/Runnables/Bases/AzSpeechRunnableBase.h
+++ b/Source/AzSpeech/Public/AzSpeech/Runnables/Bases/AzSpeechRunnableBase.h
@@ -26,9 +26,12 @@ public:
     FAzSpeechRunnableBase() = delete;
     FAzSpeechRunnableBase(UAzSpeechTaskBase* const InOwningTask, const std::shared_ptr<Microsoft::CognitiveServices::Speech::Audio::AudioConfig> InAudioConfig);
 
+    ~FAzSpeechRunnableBase();
+
     void StartAzSpeechRunnableTask();
     void StopAzSpeechRunnableTask();
 
+    bool IsRunning() const;
     bool IsPendingStop() const;
 
 protected:

--- a/Source/AzSpeech/Public/AzSpeech/Tasks/Bases/AzSpeechTaskBase.h
+++ b/Source/AzSpeech/Public/AzSpeech/Tasks/Bases/AzSpeechTaskBase.h
@@ -48,7 +48,7 @@ public:
     virtual void SetReadyToDestroy() override;
 
 protected:
-    TSharedPtr<class FAzSpeechRunnableBase> RunnableTask;
+    TUniquePtr<class FAzSpeechRunnableBase> RunnableTask;
     FName TaskName = NAME_None;
 
     FAzSpeechSubscriptionOptions SubscriptionOptions;


### PR DESCRIPTION
## Changes
1. Set runnable as unique pointer
2. Ensure that all tasks are set as ready to destroy
3. Kill the thread in runnable destruction
4. Reset the runnable pointer after setting the task as ready to destroy to force the destruction of the thread